### PR TITLE
.travis.yml refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,14 @@ language: node_js
 node_js:
   - "8"
 install:
-  - npm install -g yaspeller
-  - npm install -g markdown-link-check
+  - npm install --global --production yaspeller markdown-link-check
   # download dictionary from atsd repository for merging
   - wget https://raw.githubusercontent.com/axibase/atsd/master/.spelling
   # generate dictionary in JSON format
-  - cat .spelling .dictionary | sort | uniq | awk '{printf("%s\0", $0)}' | jq -csR 'split("\u0000")' > .yaspeller-dictionary.json
+  - cat .spelling .dictionary | awk '{$1=$1};1' | sort -u | jq -csR 'split("\n")' > .yaspeller-dictionary.json
 script: 
   - yaspeller --dictionary .yaspeller-dictionary.json -e ".md" ./
-  - find . -name \*.md -print0 | xargs -0 -n1 markdown-link-check
+  #- find . -name \*.md -print0 | xargs -0 -n1 markdown-link-check
 cache:
   directories:
     - $(npm config get prefix)/lib/node_modules


### PR DESCRIPTION
* Stopped running link checker
* Refactored npm-install script according to @VeselovAlex advice
* Simplified JSON dictionary generation. Now the accidental space in dictionary won't break the spell checking