### PR TITLE
Update lets-encrypt.md

### DIFF
--- a/workshop/lets-encrypt.md
+++ b/workshop/lets-encrypt.md
@@ -1884,6 +1884,7 @@ cat atsd_axibase_com.conf
 authorityKeyIdentifier=keyid,issuer
 basicConstraints=CA:FALSE
 keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+extendedKeyUsage=serverAuth
 subjectAltName = @alt_names
 
 [alt_names]


### PR DESCRIPTION
Our validation requires that at least one `extendedKeyUsage`  ID must be equal `serverAuth`.