### PR TITLE
docs-links-refactor

### DIFF
--- a/Analysis/CPI_PPI/README.md
+++ b/Analysis/CPI_PPI/README.md
@@ -35,7 +35,7 @@ of the Great Recession, substantial producer losses are shown by unequal changes
 
 ![](Images/pro-2.png)
 
-Using [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md#overview) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/),
+Using [SQL Console](https://axibase.com/docs/atsd/sql/) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/),
 the underlying data can be explored to calculate producer losses during the worst year of the recession for American producers:
 
 ```sql
@@ -133,7 +133,7 @@ SELECT AVG(cpi.value) AS "Avg CPI", AVG(ppi.value) AS "Avg PPI", AVG(cpi.value -
 | 188.2   | 153.7   | 34.5                  |
 ```
 
-Using the [moving average](https://github.com/axibase/atsd/blob/master/sql/README.md#aggregation-functions) function to aggregate the
+Using the [moving average](https://axibase.com/docs/atsd/sql/#aggregation-functions) function to aggregate the
 average values in annual increments instead of across the entire observed period smooths the MPV curve and shows the effects
 of the recession on producer profits. A detailed use case and syntax explanation of the weighted average function can be found
 [here](../../Support/Moving-Avg/README.md).

--- a/Analysis/Economic_Policy_Uncertainty/README.md
+++ b/Analysis/Economic_Policy_Uncertainty/README.md
@@ -9,7 +9,7 @@
 
 **Visualization Tool**: [Axibase ChartLab](https://apps.axibase.com/chartlab)
 
-**Structured Query Language (SQL)**: [Axibase SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md#overview)
+**Structured Query Language (SQL)**: [Axibase SQL Console](https://axibase.com/docs/atsd/sql/)
 
 ## Introduction
 
@@ -90,14 +90,14 @@ The European debt crisis was a financial debacle that was inflamed by the so cal
 * Mar 13, 2012: A second bailout for Greece is proposed and approved for and additional 130 billion Euro after further inspection of government financial records reveal the depth and severity of the problem is even worse than originally understood.
 * July 1, 2014: The end of the EU bailout policy, and completion of funds distribution.
 
-The following SQL query will return the [average value](https://github.com/axibase/atsd/blob/master/sql/README.md#aggregation-functions) of the EPU index for the Eurozone for the period from 2002 until 2018 and will consolidate the information using a [`round` expression](https://github.com/axibase/atsd/blob/master/sql/README.md#mathematical-functions).
+The following SQL query will return the [average value](https://axibase.com/docs/atsd/sql/#aggregation-functions) of the EPU index for the Eurozone for the period from 2002 until 2018 and will consolidate the information using a [`round` expression](https://axibase.com/docs/atsd/sql/#mathematical-functions).
 
 ```sql
 SELECT ROUND(AVG(value), 0) AS "average-epu" FROM EUEPUINDXM_
   WHERE datetime  >= '2002-01'
 ```
 
-> The `datetime` column can be compared with literal dates specified in [various date formats](https://github.com/axibase/atsd/blob/master/sql/README.md#interval-condition) including ISO 8601 and short dates such as `yyyy-MM`.
+> The `datetime` column can be compared with literal dates specified in [various date formats](https://axibase.com/docs/atsd/sql/#interval-condition) including ISO 8601 and short dates such as `yyyy-MM`.
 
 This query returns a single-entry table:
 
@@ -112,7 +112,7 @@ SELECT datetime, ROUND(value,0) FROM EUEPUINDXM_
   WHERE datetime  IN ('2002-01','2008-11','2010-02','2010-05','2010-11','2012-03','2014-07')
 ```
 
-Multiple `datetime` values can be conveniently enumerated as a list using an [`IN`](https://github.com/axibase/atsd/blob/master/sql/README.md#in-expression) expression. The above query returns these values for each of the targeted months:
+Multiple `datetime` values can be conveniently enumerated as a list using an [`IN`](https://axibase.com/docs/atsd/sql/#in-expression) expression. The above query returns these values for each of the targeted months:
 
 |Event|EPU Index Value|
 |---|:-:|
@@ -133,7 +133,7 @@ SELECT datetime, ROUND(value, 0) AS "top-epu" FROM EUEPUINDXM_
   --ORDER BY value desc LIMIT 7
 ```
 
-This query shows that none of the expected entries appear among the greatest EPU index values during the examined time period in descending order using an [`ORDER BY`](https://github.com/axibase/atsd/blob/master/sql/README.md#where-clause) expression in the `WHERE` clause.
+This query shows that none of the expected entries appear among the greatest EPU index values during the examined time period in descending order using an [`ORDER BY`](https://axibase.com/docs/atsd/sql/#ordering) expression in the `WHERE` clause.
 
 |Date|EPU Index Value|
 |---|:-:|
@@ -161,7 +161,7 @@ Using SQL queries and visualization tools, predictive algorithms and compiled in
 
 Use the following tools to recreate any of the visualizations seen here.
 
-* Install an ATSD instance on your local Linux system [here](https://github.com/axibase/atsd/blob/master/installation/README.md).
+* Install an ATSD instance on your local Linux system [here](https://axibase.com/docs/atsd/installation/).
 * Visit [FRED](https://fred.stlouisfed.org/) for any of the data used in this article.
 * Access the ChartLab sandbox, and other Axibase applications, [here](https://apps.axibase.com/) and comprehensive documentation [here](https://axibase.com/products/axibase-time-series-database/visualization/widgets/).
 * Download this [parser job file](resources/csv-parser-epu-demo.xml) which contains the settings that you can use to configure the CSV Document parser in the ATSD interface. Use this [walkthrough](../../how-to/shared/import-csv-parser.md) for help uploading the XML file to ATSD.

--- a/Analysis/Treasuries_as_Assets/README.md
+++ b/Analysis/Treasuries_as_Assets/README.md
@@ -51,7 +51,7 @@ Almost half of the United States gross public debt is held by foreign government
 The largest bearers of United States public debt are shown below. Worth noting is the fact that of the six trillion dollars
 of foreign-held debt, more than two-thirds of that amount is held by the top ten bearers shown in **Table 1**.
 
-> Structured Query Language: [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
+> Structured Query Language: [SQL Console](https://axibase.com/docs/atsd/sql/) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
 
 ```sql
 SELECT tags.country AS "Country", last(value) AS "US Debt (Billion USD)"

--- a/Bag_Tax/README.md
+++ b/Bag_Tax/README.md
@@ -45,7 +45,7 @@ increase value (+14,503 persons) which gives these estimates:
 
 Because of the 2012 implementation date of the Montgomery County Bag Tax, records about businesses' bag usage before 2012
 are scarce. However, tracking from 2012 until 2016 is possible and can be used to grade plastic bag usage using the
-[SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md#overview):
+[SQL Console](https://axibase.com/docs/atsd/sql/):
 
 ```sql
 SELECT date_format(time, 'yyyy') AS "Year", sum(value)/1000000 AS "Bag Count (Million)"

--- a/BaltimorePolice/README.md
+++ b/BaltimorePolice/README.md
@@ -27,7 +27,7 @@ a district is found to have witnessed an above average number of murders during 
 period, the alternative hypothesis will predict that the district will have also seen an
 above average number of incidents of police use of force.
 
-Both of these datasets can be analyzed in the Axibase Time Series Database which provides a built-in support for the [Socrata](https://github.com/axibase/axibase-collector/blob/master/jobs/socrata.md) Open Data format used by the majority of government agencies in the United States. ATSD also includes graphics capabilities to analyze the data with [SQL](https://github.com/axibase/atsd/blob/master/sql/README.md#overview)
+Both of these datasets can be analyzed in the Axibase Time Series Database which provides a built-in support for the [Socrata](https://github.com/axibase/axibase-collector/blob/master/jobs/socrata.md) Open Data format used by the majority of government agencies in the United States. ATSD also includes graphics capabilities to analyze the data with [SQL](https://axibase.com/docs/atsd/sql/)
 and visualize it with graphs.
 
 > For information about performing these steps in your own ATSD instance, see the [Action Items](#Action-Items)
@@ -267,7 +267,7 @@ an increase in police use of force? Do districts that see high levels of police 
 also see high levels of homicide? Is there a correlation at all?
 
 Similar to the first data set, [Socrata](https://github.com/axibase/axibase-collector/blob/master/jobs/socrata.md)
-should be used to compile the data in meaningful way and a [Structured Query Language](https://github.com/axibase/atsd/blob/master/sql/README.md#overview)
+should be used to compile the data in meaningful way and a [Structured Query Language](https://axibase.com/docs/atsd/sql/)
 should be used again.
 
 >For a more detailed explanation of performing SQL Queries, see the [Appendix](#Appendix)
@@ -606,7 +606,7 @@ GROUP BY tags.$TAG_NAME$, PERIOD(1 MONTH)
   ORDER BY tags.$TAG_NAME$, datetime
 ```
 
-Using this generic model, a series of queries can be performed in the [SQL Console](https://github.com/axibase/atsd/tree/master/sql#overview).
+Using this generic model, a series of queries can be performed in the [SQL Console](https://axibase.com/docs/atsd/sql/).
 
 The `tags.$TAG_NAME$` corresponds to the metric the user is interested in querying.
 
@@ -637,7 +637,7 @@ GROUP BY period(1 day)
   ORDER BY datetime
 ```
 
-The period of observation can be modified on the third line using a myriad of [time units](https://github.com/axibase/atsd/blob/master/api/data/series/time-unit.md).
+The period of observation can be modified on the third line using a myriad of [time units](https://axibase.com/docs/atsd/api/data/series/time-unit.html).
 
 ### Monthly Police Incident Data Without Interpolation
 

--- a/CBI_CPI/README.md
+++ b/CBI_CPI/README.md
@@ -26,12 +26,12 @@ tools, if it is preferable to perform calculations in an interface that is alrea
 examples in the documentation below to extract a series from ATSD, perform calculations in the interface of your choice, and
 then submit the new, derived series back in to ATSD:
 
-* [Alteryx Designer](https://github.com/axibase/atsd/blob/master/integration/alteryx/README.md#alteryx-designer)
-* [IBM SPSS Modeler](https://github.com/axibase/atsd/blob/master/integration/spss/modeler/README.md#ibm-spss-modeler)
-* [IBM SPSS Statistics](https://github.com/axibase/atsd/blob/master/integration/spss/statistics/README.md)
-* [Pentaho Data Integration](https://github.com/axibase/atsd/blob/master/integration/pentaho/data-integration/README.md)
-* [Pentaho Report Designer](https://github.com/axibase/atsd/blob/master/integration/pentaho/report-designer/README.md)
-* [MatLab](https://github.com/axibase/atsd/blob/master/integration/matlab/README.md)
+* [Alteryx Designer](https://axibase.com/docs/atsd/integration/alteryx/)
+* [IBM SPSS Modeler](https://axibase.com/docs/atsd/integration/spss/modeler/)
+* [IBM SPSS Statistics](https://axibase.com/docs/atsd/integration/spss/statistics/)
+* [Pentaho Data Integration](https://axibase.com/docs/atsd/integration/pentaho/data-integration/#pentaho-data-integration)
+* [Pentaho Report Designer](https://axibase.com/docs/atsd/integration/pentaho/report-designer/#pentaho-report-designer)
+* [MatLab](https://axibase.com/docs/atsd/integration/matlab/)
 
 ## Data
 

--- a/Chart_of_the_Day/Austin_Power/README.md
+++ b/Chart_of_the_Day/Austin_Power/README.md
@@ -18,7 +18,7 @@ The visualization above highlights one of the main reasons that "Public Utility"
 circles. Opponents of city-managed utilities claim government mismanagement leads to increased prices that would be positively
 affected by introducing competitors whereas proponents of regulation say just the opposite, electricity is more than a business
 it is a modern necessity, and government regulation ensures access for everyone. Using a structured query language in the
-[SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/), the numerical information associated with the above visualization is shown:
+[SQL Console](https://axibase.com/docs/atsd/sql/) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/), the numerical information associated with the above visualization is shown:
 
 ```sql
 SELECT tags.customer_class AS "Customer Class", AVG(value) AS "Avg KWH (Cents)"

--- a/Chart_of_the_Day/EU_Debt_percap/README.md
+++ b/Chart_of_the_Day/EU_Debt_percap/README.md
@@ -36,5 +36,5 @@ The following visualization tracks debt growth by country from 2006 to 2016:
 
 [![View in ChartLab](Images/button.png)](https://apps.axibase.com/chartlab/d38e750e/#fullscreen)
 
-This dataset is queried further and indexed in the [Data Library](https://axibase.com/blog/data-library/) using the [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md).
+This dataset is queried further and indexed in the [Data Library](https://axibase.com/blog/data-library/) using the [SQL Console](https://axibase.com/docs/atsd/sql/).
 See the complete entry [here](../../DataShorts/EU_Debt_percap/README.md).

--- a/Chart_of_the_Day/International_Students/README.md
+++ b/Chart_of_the_Day/International_Students/README.md
@@ -2,7 +2,7 @@
 
 * Visualization: [ChartLab](https://apps.axibase.com/chartlab) based on [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
 
-* Structured Query Language: [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md)
+* Structured Query Language: [SQL Console](https://axibase.com/docs/atsd/installation/)
 
 ![](Images/is-001.png)
 

--- a/Chart_of_the_Day/NY_Jobs/README.md
+++ b/Chart_of_the_Day/NY_Jobs/README.md
@@ -20,7 +20,7 @@ years in the Big Apple alone.
 [![View in ChartLab](Images/button.png)](https://apps.axibase.com/chartlab/6402f01c/20/)
 
 Additionally, the number of working government positions in the city has increased by roughly 38,000
-and using the [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md) from the [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/),
+and using the [SQL Console](https://axibase.com/docs/atsd/sql/) from the [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/),
 New York City figures can be compared to New York State figures:
 
 ## New York State

--- a/Chart_of_the_Day/WA_Water/README.md
+++ b/Chart_of_the_Day/WA_Water/README.md
@@ -48,7 +48,7 @@ available testing sites together.
 
 The map below shows the Top 10 Overall Best WQI site locations noted in blue, and the Bottom 10 Overall Worst WQI site locations
 noted in red. The Station ID for each site is contained in the metadata, and may be returned with this SQL
-query in the [Axibase TSD SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md#overview) and then cross-referenced
+query in the [Axibase TSD SQL Console](https://axibase.com/docs/atsd/sql/) and then cross-referenced
 to the Department of Ecology's own map (linked [here](https://fortress.wa.gov/ecy/eap/riverwq/regions/state_ContTemp.asp)):
 
 ```sql

--- a/Chart_of_the_Day/facebook/README.md
+++ b/Chart_of_the_Day/facebook/README.md
@@ -19,6 +19,6 @@ Ironically, competitor social media platform Twitter is now home to the #DeleteF
 ## Resources
 
 * [Nasdaq:FB Historical Data](https://finance.yahoo.com/quote/FB/history?p=FB) from Yahoo! Finance
-* Launch [ATSD](https://github.com/axibase/atsd/tree/master/installation#installation) on your local machine.
+* Launch [ATSD](https://axibase.com/docs/atsd/installation/) on your local machine.
 * Import this [parser job](resources/parser-job.xml) xml file for data handling.
 * [ChartLab](https://apps.axibase.com/) application and associated [documentation](https://axibase.com/products/axibase-time-series-database/visualization/widgets/)

--- a/Chart_of_the_Day/libor/README.md
+++ b/Chart_of_the_Day/libor/README.md
@@ -47,15 +47,15 @@ FROM "USD1MTD156N"
 WHERE date_format(time, 'dd') = '01'
 ```
 
-The [`WHERE`](https://github.com/axibase/atsd/tree/master/sql#where-clause) clause is used so that only one data point is used from each month, the LIBOR is a daily index so the number of returned value would be quite large without some limitations. The addition of a second [`WHERE`](https://github.com/axibase/atsd/tree/master/sql#where-clause) clause can target a specific year for a more narrowed returnset.
+The [`WHERE`](https://axibase.com/docs/atsd/sql/#where-clause) clause is used so that only one data point is used from each month, the LIBOR is a daily index so the number of returned value would be quite large without some limitations. The addition of a second [`WHERE`](https://axibase.com/docs/atsd/sql/#where-clause) clause can target a specific year for a more narrowed result set.
 
 ```sql
 WHERE date_format(time, yyyy) = '2015'
 ```
 
-Previous values may be targeted with [`LAG`](https://github.com/axibase/atsd/tree/master/sql#lag) statements and supported [mathematical functions](https://github.com/axibase/atsd/tree/master/sql#mathematical-functions) may be used in [`SELECT`](https://github.com/axibase/atsd/tree/master/sql#select-expression), `WHERE`, [`GROUP BY`](https://github.com/axibase/atsd/tree/master/sql#group-by-columns), or [`ORDER BY`](https://github.com/axibase/atsd/tree/master/sql#ordering) clauses.
+Previous values may be targeted with [`LAG`](https://axibase.com/docs/atsd/sql/#lag) statements and supported [mathematical functions](https://axibase.com/docs/atsd/sql/#mathematical-functions) may be used in [`SELECT`](https://axibase.com/docs/atsd/sql/#select-expression), `WHERE`, [`GROUP BY`](https://axibase.com/docs/atsd/sql/#group-by-columns), or [`ORDER BY`](https://axibase.com/docs/atsd/sql/#ordering) clauses.
 
-Each of the LIBOR-denominated rates may be explored by changing the [`FROM`](https://github.com/axibase/atsd/tree/master/sql#select-expression) expression to the desired metric name, stored in [ATSD](https://axibase.com/products/axibase-time-series-database/).
+Each of the LIBOR-denominated rates may be explored by changing the [`FROM`](https://axibase.com/docs/atsd/sql/#select-expression) expression to the desired metric name, stored in [ATSD](https://axibase.com/products/axibase-time-series-database/).
 
 The result set is shown here:
 
@@ -82,6 +82,6 @@ Note that months whose first day fell on a weekend or bank holiday will be exclu
 
 * For detailed instructions on using the **Trends** service, see this [guide](https://github.com/axibase/atsd-use-cases/blob/master/how-to/shared/trends.md#using-trends);
 
-* Complete [ATSD Documentation](https://github.com/axibase/atsd/blob/master/README.md);
+* Complete [ATSD Documentation](https://axibase.com/docs/atsd/);
 
-* Complete ATSD [SQL Documentation](https://github.com/axibase/atsd/tree/master/sql).
+* Complete ATSD [SQL Documentation](https://axibase.com/docs/atsd/sql/).

--- a/Chart_of_the_Day/profit-margin/README.md
+++ b/Chart_of_the_Day/profit-margin/README.md
@@ -196,7 +196,7 @@ LIMIT 10
 
 * For an introduction to the **Trends** service, see this [guide](https://github.com/axibase/atsd-use-cases/blob/master/how-to/shared/trends.md);
 
-* For complete SQL Console documentation, including syntax, clauses, and functions not show here, view the [Axibase SQL Repository](https://github.com/axibase/atsd/tree/master/sql#overview) on GitHub;
+* For complete SQL Console documentation, including syntax, clauses, and functions not show here, view the [Axibase SQL Repository](https://axibase.com/docs/atsd/sql/) on GitHub;
 
 * To access the raw data used for this article, visit [Dr. Damodaran's page](http://people.stern.nyu.edu/adamodar/New_Home_Page/datafile/margin.html);
 

--- a/Chart_of_the_Day/world-progress-explorer/README.md
+++ b/Chart_of_the_Day/world-progress-explorer/README.md
@@ -44,7 +44,7 @@ Open the **Trends** visualization and use any of the supported user-defined func
 
 ## SQL Queries
 
-Although a non-relational database, ATSD supports an SQL-like feature called [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md#overview), a convenient interface which lets users quickly query data.
+Although a non-relational database, ATSD supports an SQL-like feature called [SQL Console](https://axibase.com/docs/atsd/sql/), a convenient interface which lets users quickly query data.
 
 ### Greatest Life Expectancy for Year 2015
 
@@ -59,11 +59,11 @@ ORDER BY "Life Expectancy" DESC
 
 Query uses these clauses:
 
-* [`FROM`](https://github.com/axibase/atsd/blob/master/sql/README.md#virtual-table)
-* [Alias / `AS`](https://github.com/axibase/atsd/blob/master/sql/README.md#aliases)
-* [`WHERE`](https://github.com/axibase/atsd/blob/master/sql/README.md#where-clause)
-* [`LIMIT`](https://github.com/axibase/atsd/blob/master/sql/README.md#limiting)
-* [`ORDER BY`](https://github.com/axibase/atsd/blob/master/sql/README.md#ordering)
+* [`FROM`](https://axibase.com/docs/atsd/sql/#virtual-table)
+* [Alias / `AS`](https://axibase.com/docs/atsd/sql/#aliases)
+* [`WHERE`](https://axibase.com/docs/atsd/sql/#where-clause)
+* [`LIMIT`](https://axibase.com/docs/atsd/sql/#limiting)
+* [`ORDER BY`](https://axibase.com/docs/atsd/sql/#ordering)
 
 | Country           | Life Expectancy |
 |-------------------|-----------------|
@@ -121,8 +121,8 @@ FROM "life_expectancy_at_birth_by_country"
 
 Clauses used in this query:
 
-* [`FIRST`](https://github.com/axibase/atsd/blob/master/sql/examples/aggregate-first-last.md#aggregate-functions-first-and-last)
-* [`LAST`](https://github.com/axibase/atsd/blob/master/sql/examples/aggregate-first-last.md#aggregate-functions-first-and-last)
+* [`FIRST`](https://axibase.com/docs/atsd/sql/#first)
+* [`LAST`](https://axibase.com/docs/atsd/sql/#last)
 
 | Country                            | 1970 Value | 2015 Value | Change in Life Expectancy |
 |------------------------------------|------------|------------|---------------------------|
@@ -185,7 +185,7 @@ FROM "population_total_by_country"
 
 Clauses used in this query:
 
-* [`ROUND`](https://github.com/axibase/atsd/blob/master/sql/README.md#mathematical-functions)
+* [`ROUND`](https://axibase.com/docs/atsd/sql/#mathematical-functions)
 
 | Country       | Change in Population (Million) |
 |---------------|-----------------------------|

--- a/ChicagoCrime/README.md
+++ b/ChicagoCrime/README.md
@@ -30,7 +30,7 @@ Given the size of the dataset, you cannot load it in Excel. It is much more conv
 
 * Interactive graphs from [Chart Lab](../ChartLabIntro/README.md);
 
-* Tabular outputs from analytical [SQL queries](https://github.com/axibase/atsd/blob/master/sql/README.md#overview).
+* Tabular outputs from analytical [SQL queries](https://axibase.com/docs/atsd/sql/).
 
 You can load the dataset into an ATSD instance by following the steps provided at the [end of the article](#action-items).
 
@@ -56,7 +56,7 @@ Click on this button to explore this Chart Lab portal:
 
 [![](../BaltimorePolice/Images/button.png)](https://apps.axibase.com/chartlab/3f33d4ba/16/#fullscreen)
 
-In addition to looking at graphical outputs, we can also perform [SQL queries](https://github.com/axibase/atsd/blob/master/sql/README.md#overview), which can be used to search for specific
+In addition to looking at graphical outputs, we can also perform [SQL queries](https://axibase.com/docs/atsd/sql/), which can be used to search for specific
 information contained in this dataset. For example, we can see that 2016 months totals are greater than the previous years as a whole. But what were the average monthly totals for the last several
 years before the city experienced the horrific spike of 2016?
 

--- a/DataShorts/Austin_Housing_Market/README.md
+++ b/DataShorts/Austin_Housing_Market/README.md
@@ -2,7 +2,7 @@
 
 * Source Data: [City of Austin Report](http://www.austintexas.gov/sites/default/files/files/NHCD/2014_Comprehensive_Housing_Market_Analysis_-_Document_reduced_for_web.pdf)
 
-* Structured Query Language: [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md) in the[Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
+* Structured Query Language: [SQL Console](https://axibase.com/docs/atsd/sql/) in the[Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
 
 * Visualization: [ChartLab](https://apps.axibase.com/chartlab)
 

--- a/DataShorts/CT_Prison/README.md
+++ b/DataShorts/CT_Prison/README.md
@@ -2,7 +2,7 @@
 
 [Source Dataset](https://github.com/axibase/open-data-catalog/blob/master/datasets/f8ar-pgu4.md)
 
-[SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md)
+[SQL Console](https://axibase.com/docs/atsd/sql/)
 
 [ChartLab](https://apps.axibase.com/chartlab) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
 

--- a/DataShorts/Dollar-EX/README.md
+++ b/DataShorts/Dollar-EX/README.md
@@ -4,7 +4,7 @@ Data Source: [Federal Reserve Economic Data (FRED)](https://fred.stlouisfed.org/
 
 Visualizations: [ChartLab](https://apps.axibase.com/chartlab)
 
-Structured Query Language: [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
+Structured Query Language: [SQL Console](https://axibase.com/docs/atsd/sql/) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
 
 ## Index
 

--- a/DataShorts/EU_Debt/README.md
+++ b/DataShorts/EU_Debt/README.md
@@ -4,7 +4,7 @@
 
 **Visualization**: [ChartLab](https://apps.axibase.com/chartlab)
 
-**Structured Query Language**: [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
+**Structured Query Language**: [SQL Console](https://axibase.com/docs/atsd/sql/) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
 
 ## Debt Total
 

--- a/DataShorts/EU_Debt_percap/README.md
+++ b/DataShorts/EU_Debt_percap/README.md
@@ -6,7 +6,7 @@ Population Data Source: [EuroStat](http://ec.europa.eu/eurostat/web/population-d
 
 Visualization Tool: [ChartLab](https://apps.axibase.com/chartlab)
 
-Structured Query Language: [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
+Structured Query Language: [SQL Console](https://axibase.com/docs/atsd/sql/) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
 
 This entry is an expansion of an earlier entry titled [European Union Debt by Country](../EU_Debt/README.md).
 

--- a/DataShorts/Hong_Kong_Business/README.md
+++ b/DataShorts/Hong_Kong_Business/README.md
@@ -4,7 +4,7 @@ Data Source: [data.gov.hk](https://data.gov.hk/en-data/dataset/hk-censtatd-table
 
 Visualization: [ChartLab](https://apps.axibase.com/chartlab)
 
-Structured Query Language: [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
+Structured Query Language: [SQL Console](https://axibase.com/docs/atsd/sql/) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
 
 The data records three types of foreign companies operating in Hong Kong: local companies with foreign parent companies,
 foreign companies with locals branches in Hong Kong, and foreign companies with regional branches in Hong Kong. The differences
@@ -162,7 +162,7 @@ SELECT YEAR(time) AS 'Year', value as 'Businesses in Hong Kong',ROUND((value/ LA
 | 2015 | 18                      | 28.57            |
 | 2016 | 20                      | 11.11            |
 
-> Review [SQL Console Documentation](https://github.com/axibase/atsd/blob/master/sql/README.md#null) here to read about handling
+> Review [SQL Console Documentation](https://axibase.com/docs/atsd/sql/#null) here to read about handling
 procedures for mathematical operations involving `0`, `null`, and `NaN`.
 
 Return to the [Country Index](#country-index)
@@ -245,7 +245,7 @@ SELECT YEAR(time) AS 'Year', value as 'Businesses in Hong Kong',ROUND((value/ LA
 | 2015 | 133                     | 11.76            |
 | 2016 | 137                     | 3.01             |
 
-> Review [SQL Console Documentation](https://github.com/axibase/atsd/blob/master/sql/README.md#null) here to read about handling
+> Review [SQL Console Documentation](https://axibase.com/docs/atsd/sql/#null) here to read about handling
 procedures for mathematical operations involving `0`, `null`, and `NaN`.
 
 Return to the [Country Index](#country-index)
@@ -488,7 +488,7 @@ SELECT YEAR(time) AS 'Year', value as 'Businesses in Hong Kong',ROUND((value/ LA
 | 2015 | 42                      | -2.33            |
 | 2016 | 40                      | -4.76            |
 
-> Review [SQL Console Documentation](https://github.com/axibase/atsd/blob/master/sql/README.md#null) here to read about handling
+> Review [SQL Console Documentation](https://axibase.com/docs/atsd/sql/#null) here to read about handling
 procedures for mathematical operations involving `0`, `null`, and `NaN`.
 
 Return to the [Country Index](#country-index)
@@ -611,7 +611,7 @@ SELECT YEAR(time) AS 'Year', value as 'Businesses in Hong Kong',ROUND((value/ LA
 | 2015 | 26                      | -16.13           |
 | 2016 | 25                      | -3.85            |
 
-> Review [SQL Console Documentation](https://github.com/axibase/atsd/blob/master/sql/README.md#null) here to read about handling
+> Review [SQL Console Documentation](https://axibase.com/docs/atsd/sql/#null) here to read about handling
 procedures for mathematical operations involving `0`, `null`, and `NaN`.
 
 Return to the [Country Index](#country-index)
@@ -1329,7 +1329,7 @@ SELECT YEAR(time) AS 'Year', value as 'Businesses in Hong Kong',ROUND((value/ LA
 | 2015 | 186                     | 16.25            |
 | 2016 | 174                     | -6.45            |
 
-> Review [SQL Console Documentation](https://github.com/axibase/atsd/blob/master/sql/README.md#null) here to read about handling
+> Review [SQL Console Documentation](https://axibase.com/docs/atsd/sql/#null) here to read about handling
 procedures for mathematical operations involving `0`, `null`, and `NaN`.
 
 Return to the [Country Index](#country-index-(regional))
@@ -1612,7 +1612,7 @@ SELECT YEAR(time) AS 'Year', value as 'Businesses in Hong Kong',ROUND((value/ LA
 | 2015 | 93                      | 3.33             |
 | 2016 | 102                     |                  |
 
-> Review [SQL Console Documentation](https://github.com/axibase/atsd/blob/master/sql/README.md#null) here to read about handling
+> Review [SQL Console Documentation](https://axibase.com/docs/atsd/sql/#null) here to read about handling
 procedures for mathematical operations involving `0`, `null`, and `NaN`.
 
 Return to the [Country Index](#country-index-(regional))
@@ -1735,7 +1735,7 @@ SELECT YEAR(time) AS 'Year', value as 'Businesses in Hong Kong',ROUND((value/ LA
 | 2015 | 122                     | -15.28           |
 | 2016 | 115                     | -5.74            |
 
-> Review [SQL Console Documentation](https://github.com/axibase/atsd/blob/master/sql/README.md#null) here to read about handling
+> Review [SQL Console Documentation](hhttps://axibase.com/docs/atsd/sql/#null) here to read about handling
 procedures for mathematical operations involving `0`, `null`, and `NaN`.
 
 Return to the [Country Index](#country-index-(regional))

--- a/DataShorts/MD_Death/README.md
+++ b/DataShorts/MD_Death/README.md
@@ -2,7 +2,7 @@
 
 [Source Dataset](https://github.com/axibase/open-data-catalog/blob/master/datasets/i4x2-3kc7.md)
 
-[SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md) from [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
+[SQL Console](https://axibase.com/docs/atsd/sql/) from [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
 
 [ChartLab](https://apps.axibase.com/chartlab)
 

--- a/DataShorts/NY_Insurance/README.md
+++ b/DataShorts/NY_Insurance/README.md
@@ -3,7 +3,7 @@
 ## References
 
 * [Dataset](https://github.com/axibase/open-data-catalog/blob/master/datasets/xek8-zfrt.md)
-* [SQL Syntax](https://github.com/axibase/atsd/blob/master/sql/README.md)
+* [SQL Syntax](https://axibase.com/docs/atsd/sql/)
 * Axibase [ChartLab](https://apps.axibase.com/)
 
 ## 2015 Insurance Assets (Top 10)

--- a/DataShorts/NY_Pay/README.md
+++ b/DataShorts/NY_Pay/README.md
@@ -4,9 +4,9 @@
 
 * Visualizations: [ChartLab](https://apps.axibase.com/chartlab) from [Axibase](https://axibase.com)
 
-* Structured Query Language (SQL): [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md#overview) from [Axibase](https://axibase.com)
+* Structured Query Language (SQL): [SQL Console](https://axibase.com/docs/atsd/sql/) from [Axibase](https://axibase.com)
 
-All data is stored in the [Axibase Time Series Database](https://axibase.com). Download the Community Version [here](https://github.com/axibase/atsd/blob/master/installation/README.md#installation).
+All data is stored in the [Axibase Time Series Database](https://axibase.com). Download the Community Version [here](https://axibase.com/docs/atsd/installation/).
 
 ## Adjusted Gross Income (AGI)
 

--- a/Expatriation/2017-1.md
+++ b/Expatriation/2017-1.md
@@ -104,6 +104,6 @@ GROUP BY period(1 QUARTER)
 ## References
 
 * Title Image: [Benedict Arnold's Oath of Allegiance, May 30, 1778](https://en.wikipedia.org/wiki/Oath_of_allegiance#/media/File:Benedict_Arnold_oath_of_allegiance.jpg)
-* Axibase Time Series Database [SQL Documentation](https://github.com/axibase/atsd/blob/master/sql/README.md#overview)
+* Axibase Time Series Database [SQL Documentation](https://axibase.com/docs/atsd/sql/)
 * [Federal Register](https://www.federalregister.gov/documents/search?conditions%5Bterm%5D=Quarterly+Expatriate)
 * Wikipedia: [Quarterly Publication of Individuals Who Have Chosen to Expatriate](https://en.wikipedia.org/wiki/Quarterly_Publication_of_Individuals_Who_Have_Chosen_to_Expatriate)

--- a/Expatriation/2017-2.md
+++ b/Expatriation/2017-2.md
@@ -49,7 +49,7 @@ SELECT date_format(time,'yyyy') AS "Year", value AS "Naturalizations"
  FROM Naturalized.Citizens
 ```
 
-> Data queried in the [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md).
+> Data queried in the [SQL Console](https://axibase.com/docs/atsd/sql/).
 
 | Year | Naturalizations  |
 |------|------------------|
@@ -93,7 +93,7 @@ GROUP BY period(1 YEAR, END_TIME)
   ORDER BY period(1 YEAR, END_TIME)
 ```
 
-> The above query features robust syntax and calculated values. See the [documentation](https://github.com/axibase/atsd/blob/master/sql/README.md#examples) for syntax examples.
+> The above query features robust syntax and calculated values. See the [documentation](https://axibase.com/docs/atsd/sql/examples/) for syntax examples.
 
 | Year | Year Total | Y-o-Y Change | Y-o-Y Change, % |
 |------|------------|--------------|-----------------|

--- a/Expatriation/2017-3.md
+++ b/Expatriation/2017-3.md
@@ -25,7 +25,7 @@ As observed [last year](2017-2.md), citizens from the United States were leaving
 
 Both of the above graphs were prepared with Axibase ChartLab which is a visualization sandbox that features convenient syntax with different types of charts. The above visualizations may be modified to produce several projections of the same dataset stored in Axibase Time Series Database (ATSD).
 
-A number of built-in [statistical functions](https://github.com/axibase/atsd/blob/master/rule-engine/functions-statistical.md) are already supported by ChartLab, and [user-defined functions](../how-to/shared/trends.md#user-defined-functions) may be added to a local ATSD instance. You can follow these [instructions](https://github.com/axibase/charts/blob/master/syntax/udf.md#deploying-function-files) to upload a user-defined function as a JavaScript file.
+A number of built-in [statistical functions](https://github.com/axibase/charts/blob/master/syntax/value_functions.md#statistical-functions) are already supported by ChartLab, and [user-defined functions](../how-to/shared/trends.md#user-defined-functions) may be added to a local ATSD instance. You can follow these [instructions](https://github.com/axibase/charts/blob/master/syntax/udf.md#deploying-function-files) to upload a user-defined function as a JavaScript file.
 
 ![](Images/previous-year.png)
 [![](Images/btn.png)](https://apps.axibase.com/chartlab/a14a69a4#fullscreen)
@@ -69,7 +69,7 @@ For more information about ChartLab syntax or to explore other features which ma
 
 ## SQL
 
-In addition to ChartLab, the Axibase Time Series Database includes a web-based [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md) which can be used for ad-hoc data exploration.
+In addition to ChartLab, the Axibase Time Series Database includes a web-based [SQL Console](https://axibase.com/docs/atsd/sql/) which can be used for ad-hoc data exploration.
 
 ```sql
 SELECT date_format(time, 'yyyy') AS "Year",
@@ -105,7 +105,7 @@ GROUP BY period(1 YEAR, END_TIME)
 
 *Fig 4.* The table above shows the results of a query which tracks absolute and percentile year-on-year change in expatriate numbers, similar to the *Fig 2* and *Fig 3* above.
 
-The above query uses the [`LAG`](https://github.com/axibase/atsd/blob/master/sql/README.md#lag) function to select the previous value, offset by one index position, when creating comparative tables like the one shown here.
+The above query uses the [`LAG`](https://axibase.com/docs/atsd/sql/#lag) function to select the previous value, offset by one index position, when creating comparative tables like the one shown here.
 
 Likewise, data may be tracked by quarter using the query below:
 
@@ -144,7 +144,7 @@ GROUP BY period(1 QUARTER)
 
 *Fig 5.* Tracked by quarter, expatriation data since 2013 is shown in the table above.
 
-The above query uses a [`CAST`](https://github.com/axibase/atsd/blob/master/sql/README.md#cast) clause and [`CEIL`](https://github.com/axibase/atsd/blob/master/sql/README.md#mathematical-functions) function to rename each quarter.
+The above query uses a [`CAST`](https://axibase.com/docs/atsd/sql/#cast) clause and [`CEIL`](https://axibase.com/docs/atsd/sql/#mathematical-functions) function to rename each quarter.
 
 ## Web Crawler
 
@@ -154,7 +154,7 @@ The Web Crawler operates according to this workflow:
 
 ![](Images/crawler-flow.png)
 
-The Web Crawler reads incoming data from the Federal Register and parses it into [`series` commands](https://github.com/axibase/atsd/blob/master/api/network/series.md), readable by [ATSD](https://axibase.com/products/axibase-time-series-database/), the database which hosts all the data used in this article and supports the background operations of SQL Console. A `series` command template is shown below:
+The Web Crawler reads incoming data from the Federal Register and parses it into [`series` commands](https://axibase.com/docs/atsd/api/network/series.html), readable by [ATSD](https://axibase.com/products/axibase-time-series-database/), the database which hosts all the data used in this article and supports the background operations of SQL Console. A `series` command template is shown below:
 
 ```ls
 series d:{iso-date} e:{entity} t:{tag-1}={val-1} m:{metric-1}={number}

--- a/Expatriation/README.md
+++ b/Expatriation/README.md
@@ -122,7 +122,7 @@ The Web Crawler operates according to this workflow:
 
 ![](Images/crawler-flow.png)
 
-The Web Crawler reads incoming data from the Federal Register and parses it into [`series` commands](https://github.com/axibase/atsd/blob/master/api/network/series.md), readable by [ATSD](https://axibase.com/products/axibase-time-series-database/), the database which hosts all the data used in this article and supports the background operations of SQL Console. A `series` command template is shown below:
+The Web Crawler reads incoming data from the Federal Register and parses it into [`series` commands](https://axibase.com/docs/atsd/api/network/series.html), readable by [ATSD](https://axibase.com/products/axibase-time-series-database/), the database which hosts all the data used in this article and supports the background operations of SQL Console. A `series` command template is shown below:
 
 ```ls
 series d:{iso-date} e:{entity} t:{tag-1}={val-1} m:{metric-1}={number}
@@ -177,7 +177,7 @@ time-offset = 1 year
 
 #### `fred.PercentChangeFromYearAgo`
 
-A number of built-in [statistical functions](https://github.com/axibase/atsd/blob/master/rule-engine/functions-statistical.md) are already supported by ChartLab, and [user-defined functions](../how-to/shared/trends.md#user-defined-functions) may be added to a local ATSD instance. You can follow these [instructions](https://github.com/axibase/charts/blob/master/syntax/udf.md#deploying-function-files) to upload a user-defined function as a JavaScript file.
+A number of built-in [statistical functions](https://github.com/axibase/charts/blob/master/syntax/value_functions.md#statistical-functions) are already supported by ChartLab, and [user-defined functions](../how-to/shared/trends.md#user-defined-functions) may be added to a local ATSD instance. You can follow these [instructions](https://github.com/axibase/charts/blob/master/syntax/udf.md#deploying-function-files) to upload a user-defined function as a JavaScript file.
 
 ![](Images/2018-q2-7.png)
 

--- a/FED_FORDSR/README.md
+++ b/FED_FORDSR/README.md
@@ -21,7 +21,7 @@ about these consumers and their monetary practices to better inform their decisi
 ## Data
 
 Provided by the [Federal Reserve](https://www.federalreserve.gov/), this [dataset](https://www.federalreserve.gov/datadownload/Download.aspx?rel=FOR&series=91e0f9a6b8e6a4b1ef334ce2eaf22860&filetype=csv&label=include&layout=seriescolumn&from=01/01/1980&to=12/31/2017)
-must be correctly parsed during import. The quarterly date format needs to be converted into a monthly format that ATSD can interpret (`Q/q` letter is not supported). We also need to discard metadata lines contained in the multi-line header. This can be accomplished with a [schema-based parser](https://axibase.com/products/axibase-time-series-database/writing-data/csv/) that provides granular control over the document's rows and columns using RFC 7111 selectors and Javascript:
+must be correctly parsed during import. The quarterly date format needs to be converted into a monthly format that ATSD can interpret (`Q/q` letter is not supported). We also need to discard metadata lines contained in the multi-line header. This can be accomplished with a [schema-based parser](https://axibase.com/docs/atsd/parsers/csv/) that provides granular control over the document's rows and columns using RFC 7111 selectors and Javascript:
 
 ```javascript
 /*

--- a/FED_FORDSR/README.md
+++ b/FED_FORDSR/README.md
@@ -66,7 +66,7 @@ releases this number each quarter.
 > Use the dropdown menus at the top of the visualization screen to navigate through time, selecting the `starttime` and `endtime` values
 to observe a desired period.
 
-The data can also be queried with a structured query language in the [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md).
+The data can also be queried with a structured query language in the [SQL Console](https://axibase.com/docs/atsd/sql/).
 The data will be aggregated annually, derived from the average value of each quarter within a given year:
 
 ```sql

--- a/HawaiiGasPrices/README.md
+++ b/HawaiiGasPrices/README.md
@@ -272,7 +272,7 @@ If you would like to view a data.gov dataset without installing the ATSD softwar
 
 Below are the steps to follow to install ATSD:
 
-1. [Install the database](https://github.com/axibase/atsd/tree/master/installation#installation) on a virtual machine or in a Linux container.
+1. [Install the database](https://axibase.com/docs/atsd/installation/) on a virtual machine or in a Linux container.
 2. [Install Axibase Collector](https://github.com/axibase/axibase-collector/blob/master/installation.md#axibase-collector-installation) and configure it to write data into your ATSD instance.
 3. Import [SOCRATA Job](hawaii_gas_prices.xml) into Axibase Collector.
 4. Add your desired data.gov dataset to the job to enable data collection. Click on [Run] to collect data for the first time.

--- a/IRSTaxFilings/README.md
+++ b/IRSTaxFilings/README.md
@@ -29,7 +29,7 @@ However, the PATH Act alone cannot explain the drop in filings in the second hal
 
 Such nation-wide calendar changes, even by a few days, are worth a closer look since they affect not just the trivial events such as proverbial lines at USPS offices but have the potential to change travel patterns and even suppress retail traffic around the tax weekend. They certainly make year-on-year comparisons more tricky.
 
-To normalize the year-on-year data reported by IRS we will load the data into Axibase Time Series Database and apply the [`LAG`](https://github.com/axibase/atsd/blob/master/sql/README.md#lag) and [`INTERPOLATE`](https://github.com/axibase/atsd/blob/master/sql/README.md#regularization) functions to calculate the yearly change in both the absolute and percentage terms under three different behavioral scenarios.
+To normalize the year-on-year data reported by IRS we will load the data into Axibase Time Series Database and apply the [`LAG`](https://axibase.com/docs/atsd/sql/#lag) and [`INTERPOLATE`](https://axibase.com/docs/atsd/sql/#regularization) functions to calculate the yearly change in both the absolute and percentage terms under three different behavioral scenarios.
 
 Note that the IRS reports reference two dates used for year-on-year comparison, for example:
 
@@ -90,7 +90,7 @@ WHERE tags.section = 'Individual Income Tax Returns' AND tags.type = 'Total Retu
 ORDER BY "Day in Year", time
 ```
 
-The [`date_format`](https://github.com/axibase/atsd/blob/master/sql/README.md#date-formatting-functions) function can be conveniently used to perform date- and calendar-based filtering.
+The [`date_format`](https://axibase.com/docs/atsd/sql/#date-functions) function can be conveniently used to perform date- and calendar-based filtering.
 
 | Year | Date   | Day in Year | Curr Year, Mln | Prev Year, Mln | Year-on-Year Change, Mln | Year-on-Year Change, % |
 |------|--------|------------:|----------------------:|-------------------:|------------------:|----------------:|
@@ -230,7 +230,7 @@ You can also use [ChartLab](https://apps.axibase.com/chartlab/) to create, save,
 ## References
 
 * Title Image: [1920 Tax Season](https://upload.wikimedia.org/wikipedia/commons/archive/8/81/20060827235737%211920_tax_forms_IRS.jpg)
-* Axibase Time Series Database [SQL Documentation](https://github.com/axibase/atsd/blob/master/sql/README.md#overview)
+* Axibase Time Series Database [SQL Documentation](https://axibase.com/docs/atsd/sql/)
 * IRS [2017 and Prior Year Filing Season Statistics](https://www.irs.gov/uac/2017-and-prior-year-filing-season-statistics)
 * Reuters: "[U.S. taxpayers procrastinate on filing returns this year](http://www.reuters.com/article/us-money-taxes-delays-idUSKBN16L18C)"
 * Time: "[Fewer Americans Are Filing Their Tax Returns This Year Than in 2016](http://time.com/money/4697931/fewer-americans-filing-tax-returns/)"

--- a/IRSTaxFilings_2018/README.md
+++ b/IRSTaxFilings_2018/README.md
@@ -6,7 +6,7 @@ Interim 2018 tax filing statistics bring hope that Americans have returned to a 
 
 ### Introduction
 
-Each year the Internal Revenue Service (IRS) releases [public data](https://www.irs.gov/newsroom/2018-and-prior-year-filing-season-statistics) about the number of Americans who have filed their annual income tax paperwork. The data for 2018 shows that American filing practice is roughly in line with the previous several years although minor differences can always be detected between any two datasets. Open-source data may be visualized using [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/) and queried with [SQL console](https://github.com/axibase/atsd/blob/master/sql/README.md#overview).
+Each year the Internal Revenue Service (IRS) releases [public data](https://www.irs.gov/newsroom/2018-and-prior-year-filing-season-statistics) about the number of Americans who have filed their annual income tax paperwork. The data for 2018 shows that American filing practice is roughly in line with the previous several years although minor differences can always be detected between any two datasets. Open-source data may be visualized using [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/) and queried with [SQL console](https://axibase.com/docs/atsd/sql/).
 
 We [analyzed](../IRSTaxFilings/README.md) IRS filing statistics after Tax Day 2017 saw a higher number of people filing [later than usual](https://www.reuters.com/article/us-money-taxes-delays/u-s-taxpayers-procrastinate-on-filing-returns-this-year-idUSKBN16L18C) or [not at all](https://www.bloomberg.com/news/articles/2017-04-17/millions-of-americans-still-haven-t-filed-their-taxes) according to Reuters and Bloomberg, respectively. The income tax makes up roughly [half](https://www.nationalpriorities.org/budget-basics/federal-budget-101/revenues/) of the federal government's annual revenue (around $1.48 trillion) so a surge in late or missing filings would wreak havoc on the U.S. budget for the subsequent year.
 
@@ -179,9 +179,9 @@ ORDER BY date_format(time, 'MM-dd')
 
 Syntax Features:
 
-* [`date_format`](https://github.com/axibase/atsd/blob/master/sql/README.md#date-functions): date function which converts Unix millisecond time to a user-defined format.
-* [`LAG(columnName)`](https://github.com/axibase/atsd/blob/master/sql/README.md#lag): value function which returns the previous data point for the selected column. Very useful for time-on-time comparisons such as the one shown here.
-* [`INTERPOLATE(period)`](https://github.com/axibase/atsd/blob/master/sql/README.md#functions): value function which is used to fill gaps for irregular series. Used in this example to regularize data which has a timestamp other than the observed date.
+* [`date_format`](https://axibase.com/docs/atsd/sql/#date-functions): date function which converts Unix millisecond time to a user-defined format.
+* [`LAG(columnName)`](https://axibase.com/docs/atsd/sql/): value function which returns the previous data point for the selected column. Very useful for time-on-time comparisons such as the one shown here.
+* [`INTERPOLATE(period)`](https://axibase.com/docs/atsd/sql/examples/interpolate.html): value function which is used to fill gaps for irregular series. Used in this example to regularize data which has a timestamp other than the observed date.
 
 Result:
 
@@ -219,7 +219,7 @@ ORDER BY "Day in Year", time
 
 Syntax Features:
 
-* [`CAST`](https://github.com/axibase/atsd/blob/master/sql/README.md#cast): value function which changes a number into a string or vice versa. Time values are cast as numbers so they may be interpolated.
+* [`CAST`](https://axibase.com/docs/atsd/sql/#cast): value function which changes a number into a string or vice versa. Time values are cast as numbers so they may be interpolated.
 
 **Result:**
 
@@ -234,6 +234,6 @@ Syntax Features:
 | 2017 | Mar-30 | 89.00       | 92.47          | 94.11          | -1.64           | -1.74         |
 | 2018 | Mar-30 | 89.00       | 94.14          | 92.47          | 1.67            | 1.80          |
 
-SQL console supports the [`ROUND`](https://github.com/axibase/atsd/blob/master/sql/README.md#mathematical-functions) function for inline rounding operations of numerical values, however the SQL console interface also has a decimal precision setting which may be used to adjust date and number formatting even after the query has been completed.
+SQL console supports the [`ROUND`](https://axibase.com/docs/atsd/sql/#mathematical-functions) function for inline rounding operations of numerical values, however the SQL console interface also has a decimal precision setting which may be used to adjust date and number formatting even after the query has been completed.
 
 ![](images/dec-pre.png)

--- a/IllinoisBirthrates/README.md
+++ b/IllinoisBirthrates/README.md
@@ -32,7 +32,7 @@ the ICHS data can be visualized, modeled, and analyzed to extract valuable infor
 ## Data
 
 Analysis of these data has been divided into three sections, the first uses visualization to capture
-the information as a whole, the second queries the data in the [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md), and the third uses curve
+the information as a whole, the second queries the data in the [SQL Console](https://axibase.com/docs/atsd/sql/), and the third uses curve
 fitting to anticipate future birth rates.
 
 ### Visualizations
@@ -117,7 +117,7 @@ to 2009:
 The data is difficult to work with because of the way it is stored. Typically, time information is
 stored within a given metric, but in this case, each year is a metric in and of itself. This
 type of storage can present a number of challenges for less robust software, but using the
-[Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/) and the supported [`JOIN`](https://github.com/axibase/atsd/blob/master/sql/README.md#joins) clause,
+[Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/) and the supported [`JOIN`](https://axibase.com/docs/atsd/sql/#joins) clause,
 working with, and analyzing even unideal data is well within the scope of possibility.
 
 Birth numbers can be gathered in five-year steps:

--- a/LA_Port/README.md
+++ b/LA_Port/README.md
@@ -218,8 +218,8 @@ earnest commitment to reducing harmful greenhouse gas production.
 ## Conclusions
 
 Starting in 2006, the Port of Los Angeles has pursued effective and aggressive means to reduce the production of the most
-harmful greenhouse gases and by objective standards they have succeeded. In fact, the according to the results of the [2012
-Inventory of Air Emissions](https://www.portoflosangeles.org/pdf/2012_Air_Emissions_Inventory.pdf), the Port has outperformed
+harmful greenhouse gases and by objective standards they have succeeded. In fact, the according to the results of the 2012
+Inventory of Air Emissions (`https://www.portoflosangeles.org/pdf/2012_Air_Emissions_Inventory.pdf`), the Port has outperformed
 the ambitious goals it set for itself almost half a decade ago. As the world pushes further ahead in the quest to reduce the
 human impact on our planet, organizations like the Port of Los Angeles show that making ardent strides forward is possible
 for industries of any type, location, and size.

--- a/LA_Port/README.md
+++ b/LA_Port/README.md
@@ -74,7 +74,7 @@ The numbers associated with **Figure 2.1** are shown below:
 | 2011 | 259.0                 |
 | 2012 | 185.0                 |
 
-> This dataset is queried using the [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md#overview) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/).
+> This dataset is queried using the [SQL Console](https://axibase.com/docs/atsd/sql/) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/).
 
 To give these numbers perspective, when the study began in 2005, the Port of Los Angeles was responsible for 10% of
 all diesel particulate matter in the Los Angeles Basin: an area composed of part or all of the counties of Los Angeles,

--- a/NorwayCars/README.md
+++ b/NorwayCars/README.md
@@ -132,7 +132,7 @@ look at the statistics by following the below steps to install your own [Axibase
     ORDER BY datetime
   ```
 
-* Execute SQL queries for `nor.registered_vehicles` and `nor.registered_vehicles_by_make` to analyze statistics in tabular format using [SQL](https://github.com/axibase/atsd/blob/master/sql/README.md#overview) syntax implemented in ATSD.
+* Execute SQL queries for `nor.registered_vehicles` and `nor.registered_vehicles_by_make` to analyze statistics in tabular format using [SQL](https://axibase.com/docs/atsd/sql/) syntax implemented in ATSD.
 * Create new [visualizations](https://axibase.com/products/axibase-time-series-database/visualization/) on **Configuration > Portals** page using chart configurations from the ChartLab examples above.
 
 > Feel free to contact us with installation and technical support issues via the [feedback](https://axibase.com/feedback/) form.

--- a/OrovilleDam/README.md
+++ b/OrovilleDam/README.md
@@ -124,7 +124,7 @@ for the next several days.
 ![Figure 8](Images/Figure8.png)
 
 Is there any way we can predict how quickly the dam will fill up for a given amount of rainfall? Another very helpful tool in ATSD is the capability to perform
-[SQL queries](https://github.com/axibase/atsd/blob/master/sql/README.md#overview), which can be used to search for specific information contained in this dataset.
+[SQL queries](https://axibase.com/docs/atsd/sql/), which can be used to search for specific information contained in this dataset.
 Using this query, we are able to obtain an estimate for the volume added (acre-foot) to the storage level of the reservoir per inch of rainfall.
 
 ```sql

--- a/SF_Phone/README.md
+++ b/SF_Phone/README.md
@@ -23,7 +23,7 @@ Using public [call center data](https://catalog.data.gov/dataset/call-center-met
 San Francisco's [Health Service System](http://www.myhss.org/), which is an insurance provider to city employees, elected
 officials, and their families, call abandonment rates can be compared to call response times to establish baselines for call
 center performance and customer patience thresholds. These data will be visualized in [ChartLab](https://apps.axibase.com/chartlab)
-and dissected with the [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
+and dissected with the [SQL Console](https://axibase.com/docs/atsd/sql/) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
 and concrete wait times that are likely to result in an abandoned call will be calculated.
 
 ## Data

--- a/Support/Add-Calculated-Value/README.md
+++ b/Support/Add-Calculated-Value/README.md
@@ -16,7 +16,7 @@ When trying to beat the market each year, investment firms track their fund's pe
 as supporting evidence. Percent growth is much more broadly applicable when comparing company performance because it disregards
 the differences in overall company worth and currency value in favor of relative rates of change.
 
-Thanks to the [`replace-value`](https://axibase.com/products/axibase-time-series-database/visualization/widgets/configuring-the-widgets/) setting in [ChartLab](https://apps.axibase.com/chartlab) and support for on-the-fly value modification in [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md)
+Thanks to the [`replace-value`](https://axibase.com/products/axibase-time-series-database/visualization/widgets/configuring-the-widgets/) setting in [ChartLab](https://apps.axibase.com/chartlab) and support for on-the-fly value modification in [SQL Console](https://axibase.com/docs/atsd/sql/)
 in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/), calculations derived from underlying data do not require a secondary support program.
 Calculating a derived value and returning the results can be handled completely from within the ATSD or ChartLab user interface,
 and even exported for further use elsewhere.
@@ -76,9 +76,9 @@ SELECT date_format(time, 'yyyy') AS "Year", value AS "Debt (Million Euro)", 100*
 ORDER BY datetime
 ```
 
-This query makes use of the [`LAG`](https://github.com/axibase/atsd/blob/master/sql/README.md#lag) function, which lets the user
+This query makes use of the [`LAG`](https://axibase.com/docs/atsd/sql/#lag) function, which lets the user
 access the previous row of the same result set without robust syntax. When used with the first row in a given dataset, the `LAG` function returns
-a [`NULL`](https://github.com/axibase/atsd/blob/master/sql/README.md#null) value.
+a [`NULL`](https://axibase.com/docs/atsd/sql/#null) value.
 
 The underlying formula in this query is simple:
 

--- a/Support/Moving-Avg/README.md
+++ b/Support/Moving-Avg/README.md
@@ -132,6 +132,6 @@ airport traffic) because they are now included in the underlying data.
 
 [![View in ChartLab](Images/button.png)](https://apps.axibase.com/chartlab/a4d77c47/#fullscreen)
 
-Download the Community Edition of Axibase [here](https://github.com/axibase/atsd/blob/master/installation/README.md#installation),
+Download the Community Edition of Axibase [here](https://axibase.com/docs/atsd/installation/),
 view prepared public datasets [here](https://github.com/axibase/open-data-catalog), and contact [Axibase](https://axibase.com)
 with any questions [here](https://axibase.com/feedback/).

--- a/Support/Schema-Parser-Mod-Pre-Import/README.md
+++ b/Support/Schema-Parser-Mod-Pre-Import/README.md
@@ -139,7 +139,7 @@ value(changeSeparator(cell(row, col)))
 By manually entering the actual values provided in the data set as a `var` group and writing a simple program to convert the percent change
 values into 2010 NIS values, before the data is submitted into the Axibase Time Series Database, a new value has been calculated and inserted,
 while keeping the original value as well. The script below the comment line (######) is the schema itself. For details about writing your own schema, visit
-the Axibase Schema-Based Parsing documentation, linked [here](https://axibase.com/products/axibase-time-series-database/writing-data/csv/csv-schema/).
+the Axibase Schema-Based Parsing documentation, linked [here](https://axibase.com/docs/atsd/parsers/csv/).
 
 Because ATSD supports schema-based parsing and javascript customization, your data can be modified before you submit it for storage and kept in a form
 that is exactly as needed. The enhanced SQL query and visualization are shown below, featuring the newly calculated values:

--- a/Support/Schema-Parser-Mod-Pre-Import/README.md
+++ b/Support/Schema-Parser-Mod-Pre-Import/README.md
@@ -7,7 +7,7 @@ in a given file, or maybe calculations must be done with the given data in order
 your current needs.
 
 With [Schema-Based Parsing](https://axibase.com/products/axibase-time-series-database/writing-data/csv/csv-schema/) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
-data can be modified upon import so that working with it in the [SQL Console](https://github.com/axibase/atsd/blob/master/sql/README.md)
+data can be modified upon import so that working with it in the [SQL Console](https://axibase.com/docs/atsd/sql/)
 or [ChartLab](https://apps.axibase.com/chartlab) is more useful.
 
 ## Data

--- a/Support/Schema-Parser-Mod-Pre-Import/README.md
+++ b/Support/Schema-Parser-Mod-Pre-Import/README.md
@@ -6,7 +6,7 @@ Data is not always recorded ideally for a given analysis. Perhaps the metrics th
 in a given file, or maybe calculations must be done with the given data in order to arrive to a dataset that better suits
 your current needs.
 
-With [Schema-Based Parsing](https://axibase.com/products/axibase-time-series-database/writing-data/csv/csv-schema/) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
+With [Schema-Based Parsing](https://axibase.com/docs/atsd/parsers/csv/) in [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/)
 data can be modified upon import so that working with it in the [SQL Console](https://axibase.com/docs/atsd/sql/)
 or [ChartLab](https://apps.axibase.com/chartlab) is more useful.
 

--- a/UKAviation/README.md
+++ b/UKAviation/README.md
@@ -242,7 +242,7 @@ You can explore this portal by clicking on the link below.
 
 Below are the steps to follow to install ATSD and create figures for CAA metrics:
 
-1. [Install the database](https://github.com/axibase/atsd/tree/master/installation#installation) on a virtual machine or Linux container.
+1. [Install the database](https://axibase.com/docs/atsd/installation/) on a virtual machine or Linux container.
 2. [Install Axibase Collector](https://github.com/axibase/axibase-collector/blob/master/installation.md#axibase-collector-installation) and configure it to write data into your ATSD instance.
 3. Import the [csv-configs.xml](csv-configs.xml) into Axibase Collector.
 4. Import the [jobs.xml](jobs.xml) into Axibase Collector.

--- a/USInternationalTrade/README.md
+++ b/USInternationalTrade/README.md
@@ -25,7 +25,7 @@ While Excel can provide quick answers to simple questions, when it comes to comp
 
 * Interactive graphs from [Chart Lab](../ChartLabIntro/README.md);
 
-* Tabular outputs from analytical SQL queries with support for [partitioning](https://github.com/axibase/atsd/blob/master/sql/README.md#partitioning).
+* Tabular outputs from analytical SQL queries with support for [partitioning](https://axibase.com/docs/atsd/sql/#partitioning).
 
 You can load the dataset into any ATSD instance by following the steps provided at the [end of the article](#action-items).
 
@@ -33,7 +33,7 @@ The BLS file format presents a number of challenges when loading the data. In pa
 
 ![csv-structure](Images/csv-structure.png)
 
-ATSD handles this by implementing a [schema-based](https://github.com/axibase/atsd/blob/master/parsers/csv/csv-schema.md) parser which can be configured to load records from non-standard CSV files, such as the BLS report.
+ATSD handles this by implementing a [schema-based](https://axibase.com/docs/atsd/parsers/csv/csv-schema.html) parser which can be configured to load records from non-standard CSV files, such as the BLS report.
 
 ## Overview
 
@@ -48,7 +48,7 @@ You can explore this portal by clicking on the below button:
 
 [![View in ChartLab](Images/button.png)](https://apps.axibase.com/chartlab/552d7a44/2/#fullscreen)
 
-In addition to looking at graphical outputs, we can also perform [SQL queries](https://github.com/axibase/atsd/blob/master/sql/README.md#overview), which can be used
+In addition to looking at graphical outputs, we can also perform [SQL queries](https://axibase.com/docs/atsd/sql/), which can be used
 to search for specific information contained in this dataset. From the query below it may be observed that within the dataset time range, 1991 was the year which had the least negative trade balance of **-$66.7 billion**.
 
 ```sql

--- a/USMortality/README.md
+++ b/USMortality/README.md
@@ -8,7 +8,7 @@ According to [infoplease.com](http://www.infoplease.com/ipa/A0005148.html), life
 As reported by the [Center for Disease Control and Prevention (CDC)](http://www.cdc.gov/nchs/data/databriefs/db88.htm#x2013;2010%3C/a%3E>), the crude death rate in the United States fell from
 10.9 to 7.9 deaths per 1,000 people from 1935 to 2010, translating to a **27% decrease**. Mortality rates, however, are vastly different across different U.S. cities and age groups.
 In this article we will analyze a data.gov dataset looking at [death statistics for 122 U.S. cities](https://catalog.data.gov/dataset/deaths-in-122-u-s-cities-1962-2016-122-cities-mortality-reporting-system).
-This article will focus on Axibase Time Series Database (ATSD) [SQL query language capabilities](https://github.com/axibase/atsd/blob/master/sql/README.md#overview), which we will use to search for specific information contained in this dataset.
+This article will focus on Axibase Time Series Database (ATSD) [SQL query language capabilities](https://axibase.com/docs/atsd/sql/), which we will use to search for specific information contained in this dataset.
 
 ## Death Statistics for 122 U.S. Cities
 
@@ -120,7 +120,7 @@ simple SQL queries which will do the work for us.
 ## Basic SQL Queries
 
 Here are some basic SQL queries with brief descriptions included. Look these over to get yourself acclimated to the general format of SQL queries. In the example following this section, we will
-in detail walk through executing a query from start to finish. You can read more about our SQL syntax [here](https://github.com/axibase/atsd/blob/master/sql/README.md#syntax).
+in detail walk through executing a query from start to finish. You can read more about our SQL syntax [here](https://axibase.com/docs/atsd/sql/#syntax).
 
 ```sql
 SELECT *
@@ -186,7 +186,7 @@ ORDER BY datetime
 This final example filters records for a particular city and time. Weekly samples are aggregated into months and the sum and count of samples in each month are calculated. With the line
 `HAVING count(value) >= 4`, months with less than 4 weekly samples are excluded (October 2016 has only 1 row).
 
-You can take a look at various other [SQL queries examples on our GitHub page](https://github.com/axibase/atsd/blob/master/sql/README.md#examples).
+You can take a look at various other [SQL queries examples on our GitHub page](https://axibase.com/docs/atsd/sql/examples/).
 
 ## Detailed SQL Example 1 - Pneumonia and Influenza Deaths in Boston
 
@@ -250,7 +250,7 @@ LIMIT 10
 | mr8w-325u   | 2016-07-30T00:00:00.000Z  | 12.0       | Boston         | 1                | MA              | mr8w-325u   | 2016-07-30T00:00:00.000Z  | 120.0      | Boston         | 1                | MA             |
 ```
 
-The below query is the same as the first one we looked at, with the only difference being tags here are explicitly specified. Read more about [series tags here](https://github.com/axibase/atsd/blob/master/sql/README.md#series-tag-columns).
+The below query is the same as the first one we looked at, with the only difference being tags here are explicitly specified. Read more about [series tags here](https://axibase.com/docs/atsd/sql/#series-tag-columns).
 
 ```sql
 SELECT datetime, value, tags.city, tags.state, tags.region
@@ -262,7 +262,7 @@ LIMIT 10
 
 This next query is again for latest pneumonia and influenza and total readings for Boston, but with region code translated to region name using one of our Replacement Tables (as mentioned in the [step-by-step walk through](../USMortality/configuration.md)]). As a default, each region is listed
 by their corresponding number. In the case of Boston, it falls in region 1, which includes the states of Connecticut, Maine, Massachusetts, New Hampshire, Rhode Island, and Vermont. Recall that we created a replacement table in ATSD where
-we entered in region names for each region number. In this instance, region 1 is named **New-England**. Read more about [replacement tables here](https://github.com/axibase/atsd/blob/master/sql/README.md#lookup).
+we entered in region names for each region number. In this instance, region 1 is named **New-England**. Read more about [replacement tables here](https://axibase.com/docs/atsd/sql/#lookup-functions).
 
 ```sql
 SELECT datetime, value, tags.city, tags.state,
@@ -289,7 +289,7 @@ LIMIT 10
 ```
 
 This next query looks at total pneumonia and influenza deaths for all cities in a given region using the `GROUP BY` clause, which combines rows having common values into a single row. The region
-specified in this query is **New-England**. Read more about the `GROUP BY` clause [here](https://github.com/axibase/atsd/blob/master/sql/README.md#grouping).
+specified in this query is **New-England**. Read more about the `GROUP BY` clause [here](https://axibase.com/docs/atsd/sql/#grouping).
 
 ```sql
 SELECT datetime, sum(value),
@@ -505,7 +505,7 @@ FROM cdc.all_deaths tot
 A few noteworthy points regarding this query.
 
 1) This query has the same structure as for the query directly above, but 2 metrics are specified: `cdc.pneumonia_and_influenza_deaths` **AND** `cdc.all_deaths`.<br />
-2) `JOIN` merges records with the same entity, tags, and time. Read more about the `JOIN` clause [here](https://github.com/axibase/atsd/blob/master/sql/README.md#joins).<br />
+2) `JOIN` merges records with the same entity, tags, and time. Read more about the `JOIN` clause [here](https://axibase.com/docs/atsd/sql/#joins).<br />
 3) A derived metric, `pni.value/tot.value`, is calculated to show a percentage of the part to the total number of deaths.<br />
 4) Only weeks with more than 1 pneumonia and influenza deaths are selected with the `AND pni.value > 1` condition.<br />
 
@@ -568,7 +568,7 @@ ORDER BY 'all_deaths' DESC
 This query has a similar structure to some of the examples we have already looked at. In this example, the `LIMIT` clause caps the number of rows that can be returned,
 which in this case is 10. The line `AND datetime > current_year` returns values from 2016-01-01T00:00:00.000Z to 2016-10-01T00:00:00.000Z.
 
-The [`OPTION (ROW_MEMORY_THRESHOLD {n})`](https://github.com/axibase/atsd/blob/master/sql/README.md#row_memory_threshold-option) instructs the database to perform processing in memory as opposed to a temporary table if the number of rows is within the specified threshold {n}. If
+The [`OPTION (ROW_MEMORY_THRESHOLD {n})`](https://axibase.com/docs/atsd/sql/#row-memory-threshold-option) instructs the database to perform processing in memory as opposed to a temporary table if the number of rows is within the specified threshold {n}. If
 {n} is zero or negative, the results are processed using the temporary table.
 
 This next query examines the top 10 cities by pneumonia and influenza deaths in the current year (year to date).
@@ -1209,7 +1209,7 @@ Using our interpolated population numbers, we can see that our death rate value 
 
 Since numbers for `us.population` and the CDC metrics are collected at different frequencies (10 year vs 1 week), they have different collection periods. Therefore, it is necessary to
 calculate intermediate (weekly) population values to match the frequency of the CDC metrics. The `WITH INTERPOLATE` clause is set to 1 week to match the population periods to those of the
-CDC metrics. Read more about interpolation [here](https://github.com/axibase/atsd/blob/master/sql/README.md#interpolation).
+CDC metrics. Read more about interpolation [here](https://axibase.com/docs/atsd/sql/#interpolation).
 
 ```sql
 SELECT datetime, value

--- a/USVisa/README.md
+++ b/USVisa/README.md
@@ -24,7 +24,7 @@ Visa figures were collected for 200 countries, 7 continents, and for unknown nat
 
 As opposed to analyzing the dataset in Excel, it is much more convenient to interact with the data once it is loaded into a database. We will use two aspects of [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/) to explore this dataset:
 
-* Tabular outputs from analytical [SQL queries](https://github.com/axibase/atsd/blob/master/sql/README.md#overview);
+* Tabular outputs from analytical [SQL queries](https://axibase.com/docs/atsd/sql/);
 * Interactive graphs from [Chart Lab](../ChartLabIntro/README.md) which is similar to [`jsfiddle`](https://jsfiddle.net/).
 
 You can load the dataset into your ATSD instance by following the steps provided at the [end of the article](#action-items).
@@ -111,8 +111,8 @@ You can explore this portal by clicking on the below button:
 
 ## SQL Queries
 
-In addition to outputs from Chart Lab, ATSD is also capable of performing [SQL queries](https://github.com/axibase/atsd/blob/master/sql/README.md#overview),
-which can be used to search for specific information contained in this dataset. You can read more about our SQL syntax [here](https://github.com/axibase/atsd/blob/master/sql/README.md#syntax).
+In addition to outputs from Chart Lab, ATSD is also capable of performing [SQL queries](https://axibase.com/docs/atsd/sql/),
+which can be used to search for specific information contained in this dataset. You can read more about our SQL syntax [here](https://axibase.com/docs/atsd/sql/#syntax).
 
 This query shows the number of the most popular visas issued worldwide, except for B (travel), C (transit), G (government), and A (diplomatic). We can see that by far the greatest
 number of visas issued in 2015 (except for the above mentioned visa types) was for F-1 (student visa), for which 644,233 were issued.

--- a/USVisaRefusal/README.md
+++ b/USVisaRefusal/README.md
@@ -32,7 +32,7 @@ monetary value for visa refusal fees, we will apply these refusal rates to all v
 As opposed to analyzing this information in Excel, it is much more convenient to interact with the data once it is loaded into a database. We will use two aspects of ATSD to explore this dataset:
 
 * Interactive graphs from [Chart Lab](../ChartLabIntro/README.md);
-* Tabular outputs from analytical [SQL queries](https://github.com/axibase/atsd/blob/master/sql/README.md#overview).
+* Tabular outputs from analytical [SQL queries](https://axibase.com/docs/atsd/sql/).
 
 You can load the dataset into your ATSD instance by following the steps provided at the [end of the article](#action-items).
 
@@ -82,8 +82,8 @@ You can explore this portal by clicking on the below button:
 
 ## SQL Queries
 
-In addition to outputs from Chart Lab, ATSD is also capable of performing [SQL queries](https://github.com/axibase/atsd/blob/master/sql/README.md#overview),
-which can be used to search for specific information contained in this dataset. You can read more about our SQL syntax [here](https://github.com/axibase/atsd/blob/master/sql/README.md#syntax).
+In addition to outputs from Chart Lab, ATSD is also capable of performing [SQL queries](https://axibase.com/docs/atsd/sql/),
+which can be used to search for specific information contained in this dataset. You can read more about our SQL syntax [here](https://axibase.com/docs/atsd/sql/#syntax).
 
 This first query shows countries were refusals have increased most over the last 10 years. Surprisingly, two countries that have long been considered U.S. allies, Canada and Norway,
 saw their refusal rates considerably increase during this time period. Canada's visa refusal rate increased from **25.5%** in 2006 to **47.9%** in 2016, while in this same period Norway's

--- a/aging-america/README.md
+++ b/aging-america/README.md
@@ -11,7 +11,7 @@ The United States provides retirement security for the elderly and disabled in a
 
 ## Objectives
 
-Using [**Forecasting**](https://github.com/axibase/atsd/blob/master/forecasting/README.md#data-forecasting) functionality from [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/), current population figures and birth data, models may be created to predict trends in America's potential population crisis.
+Using [**Forecasting**](https://axibase.com/docs/atsd/forecasting/) functionality from [Axibase Time Series Database](https://axibase.com/products/axibase-time-series-database/), current population figures and birth data, models may be created to predict trends in America's potential population crisis.
 
 ## Data
 

--- a/how-to/aws/cloud-watch-alert/README.md
+++ b/how-to/aws/cloud-watch-alert/README.md
@@ -80,7 +80,7 @@ docker run -d -p 8443:8443 \
   axibase/atsd-sandbox:latest
 ```
 
-This command will start the sandbox applications, import the [rule](https://github.com/axibase/atsd/tree/master/rule-engine#rule-engine) needed for integration, and generate an incoming webhook for AWS SNS subscriptions.
+This command will start the sandbox applications, import the [rule](https://axibase.com/docs/atsd/rule-engine/) needed for integration, and generate an incoming webhook for AWS SNS subscriptions.
 
 Watch the start log for progress:
 
@@ -142,7 +142,7 @@ Navigate to the **Topics** section of the **Simple Notification Service** page o
 
 Return to the **Create Subscription** form, and paste the Webhook URL in the **Endpoint** field. Be sure that the **Protocol** drop-down menu is showing **HTTPS**.
 
-AWS SNS notifications over HTTPS protocol do not support destination endpoints with self-signed SSL certificates. If your ATSD instance is running on a self-signed certificate, switch to the HTTP protocol or install a [CA-signed SSL certificate](https://github.com/axibase/atsd/blob/master/administration/ssl-ca-signed.md) into ATSD.
+AWS SNS notifications over HTTPS protocol do not support destination endpoints with self-signed SSL certificates. If your ATSD instance is running on a self-signed certificate, switch to the HTTP protocol or install a [CA-signed SSL certificate](https://axibase.com/docs/atsd/administration/ssl-self-signed.html) into ATSD.
 
 ![](images/sns-4.png)
 
@@ -158,7 +158,7 @@ Customize the generic ATSD launch command with your preferences from these optio
 
 ### Email Notifications from ATSD
 
-Configure the [mail client](https://github.com/axibase/atsd/blob/master/administration/mail-client.md) by following the instructions here or by following the alternative launch instructions above.
+Configure the [mail client](https://axibase.com/docs/atsd/administration/mail-client.html) by following the instructions here or by following the alternative launch instructions above.
 
 Open the **Alerts** menu from the toolbar on the left and select **Rules**. By default the imported rule will be named `aws-cloudwatch-events`. Open the rule editor by clicking the rule name link. Select the **Email Notifications** tab from the toolbar along the top of the screen and update the **Recipients** field to include those addresses to whom you would like email notification to be delivered.
 
@@ -174,7 +174,7 @@ ATSD email notifications contain context-aware links to the newly launched AWS r
 
 ### Detailed Slack Notifications from ATSD
 
-Configure your local ATSD instance to send messages to **Slack Messenger** by following [this procedure](https://github.com/axibase/atsd/blob/master/rule-engine/notifications/slack.md) or adding the following environment variable to the atsd-sandbox container above:
+Configure your local ATSD instance to send messages to **Slack Messenger** by following [this procedure](https://axibase.com/docs/atsd/rule-engine/notifications/slack.html) or adding the following environment variable to the atsd-sandbox container above:
 
 ```sh
    --env SLACK_CONFIG="slack.properties"
@@ -201,7 +201,7 @@ A sample status change Slack message is shown here.
 
 ### Detailed Telegram Notifications from ATSD
 
-Configure your local ATSD instance to send messages to **Telegram Messenger** by following [this procedure](https://github.com/axibase/atsd/blob/master/rule-engine/notifications/telegram.md) or adding the following environment variable to the atsd-sandbox container above:
+Configure your local ATSD instance to send messages to **Telegram Messenger** by following [this procedure](https://axibase.com/docs/atsd/rule-engine/notifications/telegram.html) or adding the following environment variable to the atsd-sandbox container above:
 
 ```sh
    --env TELEGRAM_CONFIG="telegram.properties"

--- a/how-to/aws/route53-email-notifications/README.md
+++ b/how-to/aws/route53-email-notifications/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This guide described how to configure email alerts when a URL monitored by Route53 health checks becomes inaccessible. It also provides information on how to enhance the alerts with availability portals and outage details using Axibase Time Series Database [rule engine](https://github.com/axibase/atsd/tree/master/rule-engine#rule-engine).
+This guide described how to configure email alerts when a URL monitored by Route53 health checks becomes inaccessible. It also provides information on how to enhance the alerts with availability portals and outage details using Axibase Time Series Database [rule engine](https://axibase.com/docs/atsd/rule-engine/).
 
 ## Initial Configuration
 
@@ -83,7 +83,7 @@ Complete the process below to enhance Route53 alarms with your local ATSD instan
     Webhook URL: https://aws-cw:PASSWORD@atsd_hostname:8443/api/v1/messages/webhook/aws-cw?command.date=Timestamp&json.parse=Message&exclude=Signature;SignatureVersion;SigningCertURL;SignatureVersion;UnsubscribeURL;MessageId;Message.detail.instance-id;Message.time;Message.id;Message.version
     ```
 
-2. Configure ATSD to accept HTTPS requests from AWS infrastructure servers with a [**CA-signed**](https://github.com/axibase/atsd/blob/master/administration/ssl-ca-signed.md) SSL certificate. Alternatively, use the HTTP protocol when configuring the SNS subscription URL.
+2. Configure ATSD to accept HTTPS requests from AWS infrastructure servers with a [**CA-signed**](https://axibase.com/docs/atsd/administration/ssl-self-signed.html) SSL certificate. Alternatively, use the HTTP protocol when configuring the SNS subscription URL.
 
 3. Open the **Services** drop-down menu and navigate to the **Simple Notification Service** page in the **Application Integration** section of the menu.
 
@@ -107,23 +107,23 @@ Complete the process below to enhance Route53 alarms with your local ATSD instan
 
 You're ready to start receiving detailed email notifications about endpoint health status alerts.
 
-Follow the optional steps below to further enhance this functionality to send context-rich messages to a [collaboration service](https://github.com/axibase/atsd/blob/master/rule-engine/web-notifications.md#web-notifications) such as Slack or Telegram.
+Follow the optional steps below to further enhance this functionality to send context-rich messages to a [collaboration service](https://axibase.com/docs/atsd/rule-engine/notifications/) such as Slack or Telegram.
 
 ### Alarm Notifications in Slack
 
-* Configure your local ATSD instance to send messages to **Slack Messenger** by following [this procedure](https://github.com/axibase/atsd/blob/master/rule-engine/notifications/slack.md). Now, your alarm notifications will be sent via Slack messages as well as email.
+* Configure your local ATSD instance to send messages to **Slack Messenger** by following [this procedure](https://axibase.com/docs/atsd/rule-engine/notifications/slack.html). Now, your alarm notifications will be sent via Slack messages as well as email.
 
 ![](images/route53-alert-slack.png)
 
 ### Alarm Notifications in Telegram
 
-* Configure your local ATSD instance to send messages to **Telegram Messenger** by following [this procedure](https://github.com/axibase/atsd/blob/master/rule-engine/notifications/telegram.md). Now, your alarm notifications will be sent via Telegram messages as well as email.
+* Configure your local ATSD instance to send messages to **Telegram Messenger** by following [this procedure](https://axibase.com/docs/atsd/rule-engine/notifications/telegram.html). Now, your alarm notifications will be sent via Telegram messages as well as email.
 
 ![](images/route53-tg-alert.png)
 
 ### Advanced Configuration
 
-* To configure advanced settings, expand the **Alerts** menu and select **Rules**. Follow the procedure described [here](https://github.com/axibase/atsd/blob/master/rule-engine/web-notifications.md#attachments) to include detailed reports and portals in your alert emails.
+* To configure advanced settings, expand the **Alerts** menu and select **Rules**. Follow the procedure described [here](https://axibase.com/docs/atsd/rule-engine/notifications/#attachments) to include detailed reports and portals in your alert emails.
 
 * Enable the **Attach Details** option to include detailed email reports upon alarm notification:
 

--- a/how-to/aws/route53-health-checks/uptime-report.md
+++ b/how-to/aws/route53-health-checks/uptime-report.md
@@ -52,7 +52,7 @@ This completes the verification stage. You now have data which can be reported o
 
 ## Reports
 
-Since we need a flexible way of filtering, grouping, and formatting results, we will rely on [SQL](https://github.com/axibase/atsd/blob/master/sql/README.md) implemented in Axibase Time Series Database to prepare reports, including time series extensions for time-zone aggregations.
+Since we need a flexible way of filtering, grouping, and formatting results, we will rely on [SQL](https://axibase.com/docs/atsd/sql/) implemented in Axibase Time Series Database to prepare reports, including time series extensions for time-zone aggregations.
 
 In ATSD, SQL queries can be executed via web-based console, an external reporting tool using a JDBC/ODBC driver, or with the built-in report generator with email delivery, web publishing, and file generation options. We will rely on the web-based SQL console to test and fine-tune these queries.
 
@@ -83,7 +83,7 @@ The output includes the list of health check IDs and the average percentage heal
 
 The 'Sample Count' column is present for data quality control purposes. Since checks are reported every minute, the number of samples in the report should be equal to the number of hours in the reporting interval multiplied by `60`. In the above case, the number of hours was `24` and therefore the sample count is `24*60 = 1440`.
 
-You can adjust the start and end date of the reporting interval using convenient [calendar](https://github.com/axibase/atsd/blob/master/shared/calendar.md) syntax. For example, to view availability for the previous quarter, specify the date condition as follows:
+You can adjust the start and end date of the reporting interval using convenient [calendar](https://axibase.com/docs/atsd/shared/calendar.html) syntax. For example, to view availability for the previous quarter, specify the date condition as follows:
 
 * Last 24-hours:
 
@@ -132,7 +132,7 @@ GROUP BY entity
 
 ### Filtering By Property
 
-The report can be filtered by an entity tag using [string operators](https://github.com/axibase/atsd/blob/master/sql/README.md#where-clause) such as `=`, `!=`, and `LIKE`.
+The report can be filtered by an entity tag using [string operators](https://axibase.com/docs/atsd/sql/#where-clause) such as `=`, `!=`, and `LIKE`.
 
 ```sql
 SELECT entity.tags.url AS URL, entity.tags.protocol AS "Protocol",

--- a/how-to/database/historize/README.md
+++ b/how-to/database/historize/README.md
@@ -249,9 +249,9 @@ To view individual series, click on the **Series** icon and then on the chart li
 
 Now that you have data being continuously inserted into ATSD, you can:
 
-* Visualize data with [portals](https://github.com/axibase/atsd/blob/master/portals/README.md). Show hourly orders overlaid with previous day/week/etc.
+* Visualize data with [portals](https://axibase.com/docs/atsd/portals/). Show hourly orders overlaid with previous day/week/etc.
 
 ![](images/order-chart.png)
 
-* Build automated [forecasts](https://github.com/axibase/atsd/blob/master/forecasting/README.md).
-* Create Slack/email [alerts](https://github.com/axibase/atsd/blob/master/rule-engine/web-notifications.md#collaboration-services) using the [rule engine](https://github.com/axibase/atsd/tree/master/rule-engine#rule-engine) to get notified when the order activity is abnormal.
+* Build automated [forecasts](https://axibase.com/docs/atsd/forecasting/).
+* Create Slack/email [alerts](https://axibase.com/docs/atsd/rule-engine/notifications/#creating-notifications) using the [rule engine](https://axibase.com/docs/atsd/rule-engine/) to get notified when the order activity is abnormal.

--- a/how-to/docker/README.md
+++ b/how-to/docker/README.md
@@ -12,7 +12,7 @@ While the email option can serve as a work-around for build failures, it's diffi
 
 ![](images/docker-email.png)
 
-This guide describes a solution, based on the rule engine implemented in [Axibase Time Series Database](https://github.com/axibase/atsd/tree/master/rule-engine#rule-engine), which polls the Docker Hub build history using the Docker Hub v2 API and generates missing webhooks in case of **build failures** or if the build is queued for more than one hour (this threshold is configurable).
+This guide describes a solution, based on the rule engine implemented in [Axibase Time Series Database](https://axibase.com/docs/atsd/rule-engine/), which polls the Docker Hub build history using the Docker Hub v2 API and generates missing webhooks in case of **build failures** or if the build is queued for more than one hour (this threshold is configurable).
 
 Please note that this solution only applies to automated builds which are executed by Docker Hub itself.
 
@@ -194,11 +194,11 @@ In addition to sending build error notifications, the `dockerhub-build-fail` rul
 
     ![](images/docker-hub-trigger-rule.png)
 
-For a more robust implementation, create a [lookup table](https://github.com/axibase/atsd/blob/master/rule-engine/functions-lookup.md#lookup) to associate images in incoming failure events with trigger tokens.
+For a more robust implementation, create a [lookup table](https://axibase.com/docs/atsd/rule-engine/functions.html#lookup) to associate images in incoming failure events with trigger tokens.
 
 ### Send Alerts
 
-You can also customize the rule to send alerts into your preferred messaging service such as [Slack](https://github.com/axibase/atsd/blob/master/rule-engine/notifications/slack.md) or Rocket.Chat.
+You can also customize the rule to send alerts into your preferred messaging service such as [Slack](https://axibase.com/docs/atsd/rule-engine/notifications/slack.html) or Rocket.Chat.
 
 ![](images/rocket-alert.png)
 
@@ -262,6 +262,6 @@ The target service should now receive the JSON payload:
 
 ## References
 
-* Axibase Time Series Database [rule engine documentation](https://github.com/axibase/atsd/tree/master/rule-engine#rule-engine).
+* Axibase Time Series Database [rule engine documentation](https://axibase.com/docs/atsd/rule-engine/).
 * Axibase Collector [JSON job documentation](https://github.com/axibase/axibase-collector/blob/master/jobs/json.md).
 * Questions? Issues? Please contact us via an [issue](https://github.com/axibase/atsd-use-cases/issues/new) form.

--- a/how-to/github/pr-report.md
+++ b/how-to/github/pr-report.md
@@ -81,7 +81,7 @@ Upon successful completion, the **Mail Client** will automatically send subscrib
 
 ![](images/test-email.png)
 
-After initial launch, if **Mail Client** settings need to be reconfigured, follow these [instructions](https://github.com/axibase/atsd/blob/master/administration/mail-client.md#mail-client).
+After initial launch, if **Mail Client** settings need to be reconfigured, follow these [instructions](https://axibase.com/docs/atsd/administration/mail-client.html).
 
 ATSD web interface is accessible at [`https://docker_host:8443/`](https://github.com/axibase/dockers/tree/atsd-sandbox#exposed-ports).
 
@@ -382,7 +382,7 @@ This query targets [Apache Software Foundation](https://github.com/apache) repos
 </p>
 </details>
 
-The GraphQL query returns a JSON list of Pull Requests based on `MERGEABLE` status. Among the five returned Pull Requests, one has `'SUCCESS'` state, two have `'FAILURE'` state, and two have `'PENDING'` state. ATSD [Rule Engine](https://github.com/axibase/atsd/tree/master/rule-engine#rule-engine) filters these results with `JSONPath` syntax:
+The GraphQL query returns a JSON list of Pull Requests based on `MERGEABLE` status. Among the five returned Pull Requests, one has `'SUCCESS'` state, two have `'FAILURE'` state, and two have `'PENDING'` state. ATSD [Rule Engine](https://axibase.com/docs/atsd/rule-engine/) filters these results with `JSONPath` syntax:
 
 ```ls
 $..pullRequests.nodes[?(@.mergeable == 'MERGEABLE' && @.pullRequestcommits.nodes[0].commit.status.state == 'SUCCESS')]
@@ -519,7 +519,7 @@ Each of these JSONPaths will return a unique JSON list which ATSD Rule Engine wi
 </p>
 </details>
 
-ATSD [Rule Engine](https://github.com/axibase/atsd/tree/master/rule-engine#rule-engine) receives incoming JSON result sets and converts them into human-readable HTML reports. Rule Engine generates reports based on [Conditions](https://github.com/axibase/atsd/tree/master/rule-engine#condition-checking), in this case, immediately after the first sandbox launch and then daily at 5:00 AM server local time. The report is created by [Email Action](https://github.com/axibase/atsd/blob/master/rule-engine/email.md#email-action) which convert the JSON output into HTML table via [`jsonToLists`](https://github.com/axibase/atsd/blob/master/rule-engine/functions-table.md#jsontolists) function.
+ATSD [Rule Engine](https://axibase.com/docs/atsd/rule-engine/) receives incoming JSON result sets and converts them into human-readable HTML reports. Rule Engine generates reports based on [Conditions](https://axibase.com/docs/atsd/rule-engine/#condition-checking), in this case, immediately after the first sandbox launch and then daily at 5:00 AM server local time. The report is created by [Email Action](https://axibase.com/docs/atsd/rule-engine/email.html) which convert the JSON output into HTML table via [`jsonToLists`](https://axibase.com/docs/atsd/rule-engine/functions-table.html#jsontolists) function.
 
 The above JSON result sets will be converted to two outgoing email reports, sent to the defined subscriber list.
 

--- a/how-to/github/troubleshooting.md
+++ b/how-to/github/troubleshooting.md
@@ -1,6 +1,6 @@
 # Incoming Webhook Troubleshooting
 
-Correct common problems with incoming [webhooks](https://github.com/axibase/atsd/blob/master/api/data/messages/webhook.md).
+Correct common problems with incoming [webhooks](https://axibase.com/docs/atsd/api/data/messages/webhook.html).
 
 ## Confirm Connectivity
 

--- a/how-to/shared/import-entity-group.md
+++ b/how-to/shared/import-entity-group.md
@@ -4,7 +4,7 @@
 
 Entity Groups provide a way to organize similar entities into logical collections that can be operated on as aggregates when managing user permissions, filtering data, calculating statistics, etc.
 
-For more information on entity groups, see the [documentation](https://github.com/axibase/atsd/blob/master/configuration/entity_groups.md).
+For more information on entity groups, see the [documentation](https://axibase.com/docs/atsd/configuration/entity_groups.html).
 
 Follow this procedure to import an Entity Group definition to your local ATSD instance.
 

--- a/how-to/shared/import-entity-view.md
+++ b/how-to/shared/import-entity-view.md
@@ -2,7 +2,7 @@
 
 ![](images/entity-views.png)
 
-Entity Views display a custom set of attributes and statistics for the members of the selected Entity Group. The information displayed by an entity view is presented in a tabular format and is updated when the page is refreshed. Entity Views can be added to the top menu. For more information on entity views, see the [documentation](https://github.com/axibase/atsd/blob/master/configuration/entity_views.md).
+Entity Views display a custom set of attributes and statistics for the members of the selected Entity Group. The information displayed by an entity view is presented in a tabular format and is updated when the page is refreshed. Entity Views can be added to the top menu. For more information on entity views, see the [documentation](https://axibase.com/docs/atsd/configuration/entity_views.html).
 
 Follow this process to upload an Entity View configuration to your local ATSD instance.
 

--- a/how-to/shared/import-entity.md
+++ b/how-to/shared/import-entity.md
@@ -2,7 +2,7 @@
 
 ![](images/entity-group.png)
 
-An entity configuration describes the monitored object. The [entity record](https://github.com/axibase/atsd/blob/master/api/meta/entity/list.md#fields) includes information about the object such as the name, label, and custom tags.
+An entity configuration describes the monitored object. The [entity record](https://axibase.com/docs/atsd/api/meta/entity/list.html#fields) includes information about the object such as the name, label, and custom tags.
 
 Follow this process to import entity records into your local ATSD instance.
 

--- a/how-to/shared/import-forecast.md
+++ b/how-to/shared/import-forecast.md
@@ -2,7 +2,7 @@
 
 ![](images/forecast-title.png)
 
-[Forecast Settings](https://github.com/axibase/atsd/tree/master/forecasting) is a set of rules to predict future data by applying a statistical algorithm to historical records.  The choice of the algorithm and its parameters may be manually specified by an expert user or automatically selected by ATSD based on the built-in scoring system.
+[Forecast Settings](https://axibase.com/docs/atsd/forecasting/) is a set of rules to predict future data by applying a statistical algorithm to historical records.  The choice of the algorithm and its parameters may be manually specified by an expert user or automatically selected by ATSD based on the built-in scoring system.
 
 Follow this process to upload a forecast configuration to your local ATSD instance.
 

--- a/how-to/shared/import-metric.md
+++ b/how-to/shared/import-metric.md
@@ -2,7 +2,7 @@
 
 ![](images/metric.png)
 
-Metrics are numeric measurements stored in ATSD. The [metric record](https://github.com/axibase/atsd/blob/master/api/meta/metric/list.md#fields) includes information about the measured attribute including its name, a user-friendly label, measurement units etc.
+Metrics are numeric measurements stored in ATSD. The [metric record](https://axibase.com/docs/atsd/api/meta/metric/list.html#fields) includes information about the measured attribute including its name, a user-friendly label, measurement units etc.
 
 Follow this process to import metric definitions into your local ATSD instance.
 

--- a/how-to/shared/trends.md
+++ b/how-to/shared/trends.md
@@ -176,7 +176,7 @@ Open any of the visualizations above to see syntax and visual demonstrations of 
 
 ## Further Reading
 
-For more detailed information about ATSD, the underlying mechanics, or download instructions see the [ATSD Documentation](https://github.com/axibase/atsd).
+For more detailed information about ATSD, the underlying mechanics, or download instructions see the [ATSD Documentation](https://axibase.com/docs/atsd/).
 
 Reach out to us with questions, comments, or suggestions [here](mailto:hello@axibase.com) via email or [here](https://github.com/axibase/atsd-use-cases/issues) on our GitHub page.
 

--- a/workshop/lets-encrypt.md
+++ b/workshop/lets-encrypt.md
@@ -1016,7 +1016,7 @@ public class CertListChain {
 
 #### Self-Signed Certificate Chain
 
-[Self-Signed](https://github.com/axibase/atsd/blob/master/administration/ssl-ca-signed.md) certificates have no chain.
+[Self-Signed](https://axibase.com/docs/atsd/administration/ssl-self-signed.html) certificates have no chain.
 
 The subject is the same as the issuer.
 
@@ -1028,7 +1028,7 @@ The subject is the same as the issuer.
 
 #### CA-Signed Certificate Chain
 
-[CA-Signed](https://github.com/axibase/atsd/blob/master/administration/ssl-ca-signed.md) Certificate.
+[CA-Signed](https://axibase.com/docs/atsd/administration/ssl-ca-signed.html) Certificate.
 
 ```txt
   Subject = CN=*.axibase.com, OU=PositiveSSL Wildcard, OU=Domain Control Validated
@@ -1194,7 +1194,7 @@ No TRUSTED root certificate found for CN=atsd.axibase.com, OU=Unknown, O=Unknown
 
 ### Self-Signed Certificate
 
-Use [keytool](https://github.com/axibase/atsd/blob/master/administration/ssl-self-signed.md#generate-certificate) to generate and install a self-signed certificate.
+Use [keytool](https://axibase.com/docs/atsd/administration/ssl-self-signed.html#generate-certificate) to generate and install a self-signed certificate.
 
 The default certificate in ATSD is issued for 'atsd' CN and 'atsd' alias.
 
@@ -1675,7 +1675,7 @@ Certificate details including DNS names are now publicly available even if the c
 
 Publicly-accessible certificate database.
 
-Table schema is available on [github](https://github.com/crtsh/certwatch_db/blob/master/create_schema.sql).
+Table schema is available on [GitHub](https://github.com/crtsh/certwatch_db/blob/master/create_schema.sql).
 
 ```ls
 Database.URL = jdbc:postgresql://crt.sh:5432/certwatch


### PR DESCRIPTION
PR refactors all use-cases articles to link to axibase.com instead of github when referencing docs.