### PR TITLE
css-to-ls

### DIFF
--- a/chart-of-the-day/crypto/README.md
+++ b/chart-of-the-day/crypto/README.md
@@ -30,13 +30,13 @@ Open the visualization and modify the `var positions` and `value` settings in th
 
 The default configuration tracks a custom investment of $100 Bitcoin, $400 Etherium, $100 Litecoin, and $400 Bitcoin Cash.
 
-```css
+```ls
 var positions = [['btc', 100], ['eth', 400], ['ltc', 100], ['bch', 400]]  
 ```
 
 Modify the `value` setting to customize the date of purchase. By default, the investment is purchased at `2018-01-01` prices.
 
-```css
+```ls
 value = +value('@{position[0]}')*@{position[1]}/fred.ValueForDate('@{position[0]}','2018-01-01')
 ```
 

--- a/chart-of-the-day/water-portal/README.md
+++ b/chart-of-the-day/water-portal/README.md
@@ -29,7 +29,7 @@ The above photographs show the Folsom reservoir, the main reservoir responsible 
 
 This portal tracks Folsom reservoir levels using a `time-offset` setting to display variable year data together.
 
-```css
+```ls
 list ofs = 0, 1, 2, 3, 4, 5, 10
 for offs in ofs
   [series]
@@ -51,7 +51,7 @@ Despite heavy rainfall which sparked the [Oroville Dam crisis](../../research/or
 
 To compensate for the increased rainfall, use an [aggregation function](https://axibase.com/products/axibase-time-series-database/visualization/widgets/configuring-the-widgets/) to smooth the trend lines. Each marker denotes the user-defined period of `1 week`.
 
-```css
+```ls
 [widget]
   group-statistic = avg
   group-period = 1 week
@@ -115,7 +115,7 @@ The lake is dammed by the Monticello Dam, where detailed precipitation data is t
 
 Immediately visible is that current year data is barely noticeable among other samples. Use the `time period` labels at the top of the visualization to compare `10 years ago` and `0 years ago` or open the **ChartLab** portal where other data is excluded.
 
-```css
+```ls
 list ofs = 0, 10
 for offs in ofs
 ```

--- a/integrations/itm/resources/metric-list.md
+++ b/integrations/itm/resources/metric-list.md
@@ -2,7 +2,7 @@
 
 ## Linux OS
 
-```ls
+```css
 klzcpu.busy_cpu
 klzcpu.busyc_whsc
 klzcpu.idle_cpu
@@ -538,7 +538,7 @@ lnxvm.virtual_storage_pct_used
 
 ## VMware
 
-```ls
+```css
 kvmcltrdst.accessible
 kvmcltrdst.capacity
 kvmcltrdst.connected_hosts
@@ -563,7 +563,7 @@ kvmcltrsrv.server_cpu_utilization
 
 ## WebSphere MQ
 
-```ls
+```css
 Name
 mq.channel_statistics.batches_complete
 mq.channel_statistics.buffers_received

--- a/integrations/itm/resources/metric-list.md
+++ b/integrations/itm/resources/metric-list.md
@@ -2,7 +2,7 @@
 
 ## Linux OS
 
-```css
+```ls
 klzcpu.busy_cpu
 klzcpu.busyc_whsc
 klzcpu.idle_cpu
@@ -538,7 +538,7 @@ lnxvm.virtual_storage_pct_used
 
 ## VMware
 
-```css
+```ls
 kvmcltrdst.accessible
 kvmcltrdst.capacity
 kvmcltrdst.connected_hosts
@@ -563,7 +563,7 @@ kvmcltrsrv.server_cpu_utilization
 
 ## WebSphere MQ
 
-```css
+```ls
 Name
 mq.channel_statistics.batches_complete
 mq.channel_statistics.buffers_received

--- a/research/water-turbidity/README.md
+++ b/research/water-turbidity/README.md
@@ -78,7 +78,7 @@ The dataset is inconsistent. Some years lack data for certain locations, and oth
 
 View data from other years by modifying the `starttime` expression or isolate a series by clicking the `Beach Name` tag icons above the visualization to toggle the presence of the detector from that location.
 
-```css
+```ls
 [configuration]
   starttime = May 2016
 ```
@@ -101,7 +101,7 @@ The formula associated with Snell's law `n1/n2 =  sin(θ1)/sin(θ2)` states that
 
 Aggregating temperature and turbidity data by the day is a reasonable resolution to the problem of volatile samples considering the observed period is less than six months for each year.
 
-```css
+```ls
 [widget]
   group-period = 1 day
   group-statistic = avg
@@ -115,7 +115,7 @@ Aggregating temperature and turbidity data by the day is a reasonable resolution
 
 The `PercentChangeByOffset` function is used below to handle the difference in magnitude of the two metrics and compare relative changes. The `PercentChangeByOffset` function requires two arguments: the `alias` of the series to transform, and the `interval` of the offset.
 
-```css
+```ls
 [series]
   value = local.PercentChangeByOffset('raw-turb', '1 day')
 [series]
@@ -138,14 +138,14 @@ The converse relationship of turbidity and water temperature is visualized above
 
 The pattern is similar when comparing absolute daily average change but the `PercentChangeByOffset` is preferable since absolute turbidity changes are greater than absolute temperature changes. Converting the Celsius temperature values to Fahrenheit is one solution to increase variance.
 
-```css
+```ls
 [series]
   replace-value =  ((value - previousValue) * 9/5 + 32)
 ```
 
 Modifying the derived `value` expression in the visualization created using the `PercentChangeByOffset` function to reflect the `Water Temperature` line about the `x` axis and reducing the observed `time-span` generates a more coherent visualization of the relationship.
 
-```css
+```ls
 [configuration]
   time-span = 20 day
 

--- a/trends/housing-index/README.md
+++ b/trends/housing-index/README.md
@@ -12,7 +12,7 @@
 
 The visualization above uses the [Housing Consumer Price Index](https://fred.stlouisfed.org/series/CUUS0000SAH) and [Average Sales Price for New Houses in the United States](https://fred.stlouisfed.org/series/ASPNHSUS) datasets to create a derived Housing Price Index.
 
-```css
+```ls
 [series]
   value = (value('price') / value('index'))
 ```
@@ -32,7 +32,7 @@ This visualization tracks the number of housing projects initiated against the n
 
 Import a custom library and call user-defined functions by name:
 
-```css
+```ls
 [configuration]
   import fred = fred.js
 
@@ -48,7 +48,7 @@ Import a custom library and call user-defined functions by name:
 
 Another important set of metrics track the start and end of housing projects. During growth period, you can see that the number of new projects consistently outstrips the number of completed projects, indicating a period a growth. During the housing crisis, this trend reversed significantly. In fact, the difference is more negative than growth periods are positive, showing the severity of the crisis.
 
-```css
+```ls
 [series]
   value = value('hou') - value('comp')
   alert-expression = value < 0
@@ -63,7 +63,7 @@ To illustrate the severity of the housing market crisis with respect to the diff
 
 [![](./images/button-new.png)](https://trends.axibase.com/75bc2e31)
 
-```css
+```ls
 [series]
   value = Math.abs(value('hou') - value('comp'))
   alert-expression = value('comp') > value('hou');
@@ -86,7 +86,7 @@ The Federal Reserve records data for types of residences built as well.
 
 The [Pie Chart](https://axibase.com/products/axibase-time-series-database/visualization/widgets/pie-chart-widget/#tab-id-1) tracks the annual total for each type of project. Navigate through time using the drop-down list in the portal above. Expand the `range` to view data outside the scope of this article. The Federal Reserve tracks  from completed projects 1971 to the present.
 
-```css
+```ls
 [dropdown]
  options = @{range(2000,2018)}
  change-field = starttime

--- a/tutorials/irregular-timestamp/README.md
+++ b/tutorials/irregular-timestamp/README.md
@@ -64,7 +64,7 @@ Using [**ChartLab**](../shared/chartlab.md), the DOP dataset is parsed to create
 
 The declarative [Charts Syntax](https://axibase.com/products/axibase-time-series-database/visualization/widgets/time-chart/) defines the `entity` and `metric` created by the parser upon import:
 
-```css
+```ls
 [series]
   entity = data.cityofnewyork.us
   metric = juvenile_rearrest_rate

--- a/tutorials/schema-based-parser-mod/README.md
+++ b/tutorials/schema-based-parser-mod/README.md
@@ -93,7 +93,7 @@ In a local instance of ATSD open the **Data > CSV Parsers** page, scroll to the 
 
 ![](./images/SBP_2.1.png)
 
-```css
+```ls
 var dataPer2016 = ['2016',341267,319631,183461,135824,15268,367246,356431,10984,268057,89354,21465]; // numbers for 2016
 function calcAccumulatedPercent(row, col) {
     var accCoef = 1;

--- a/tutorials/subtract-subsequent-values/README.md
+++ b/tutorials/subtract-subsequent-values/README.md
@@ -182,7 +182,7 @@ To calculate and display the difference between consecutive values, there are th
 
 Use the `rate` setting to calculate the difference between the current data sample and the previous sample and return the difference in place of the current data sample.
 
-```css
+```ls
 [series]
   rate = 0 minute
   rate-counter = false
@@ -220,7 +220,7 @@ The visualization created by the `rate` setting configuration is shown below.
 
 Use `value` and `previousValue` fields in the [`replace-value`](https://axibase.com/products/axibase-time-series-database/visualization/widgets/configuring-the-widgets/) function.
 
-```css
+```ls
 [series]
 replace-value = value - previousValue
 ```
@@ -231,7 +231,7 @@ replace-value = value - previousValue
 
 Create a derived series using the [`previous(alias)`](https://github.com/axibase/charts/blob/master/syntax/functions.md#previous) function.  Hide both the raw series and the derived series. Create a third series and calculate the difference in consecutive values for each timestamp by referencing values of the hidden series.
 
-```css
+```ls
 /* raw series data */
 [series]
  alias = raw

--- a/tutorials/workshop/lets-encrypt.md
+++ b/tutorials/workshop/lets-encrypt.md
@@ -243,7 +243,7 @@ ls /usr/share/ca-certificates/mozilla/
 
 <details><summary><b>View Ubuntu 14.04 CAs</b></summary>
 
-```css
+```ls
 ACCVRAIZ1.crt                                                       Global_Chambersign_Root_-_2008.crt
 ACEDICOM_Root.crt                                                   GlobalSign_ECC_Root_CA_-_R4.crt
 AC_RAIZ_FNMT-RCM.crt                                                GlobalSign_ECC_Root_CA_-_R5.crt
@@ -1184,7 +1184,7 @@ public class CertTrust {
 
 Validation results for Expired Certificate:
 
-```css
+```ls
 Certificate chain validation failed: java.security.cert.CertPathValidatorException: timestamp check failed :
   java.security.cert.CertificateExpiredException: NotAfter: Sat Mar 17 02:59:59 MSK 2018
 Default trust manager: certificate chain validation failed:
@@ -1195,7 +1195,7 @@ Default trust manager: certificate chain validation failed:
 
 Validation Results for Self-Signed Certificate:
 
-```css
+```ls
 Certificate chain validation failed: java.security.cert.CertPathValidatorException: Path does not chain with any of the trust anchors : null
 
 Default trust manager: certificate chain validation failed: sun.security.validator.ValidatorException: PKIX path building failed:

--- a/tutorials/workshop/lets-encrypt.md
+++ b/tutorials/workshop/lets-encrypt.md
@@ -243,7 +243,7 @@ ls /usr/share/ca-certificates/mozilla/
 
 <details><summary><b>View Ubuntu 14.04 CAs</b></summary>
 
-```ls
+```txt
 ACCVRAIZ1.crt                                                       Global_Chambersign_Root_-_2008.crt
 ACEDICOM_Root.crt                                                   GlobalSign_ECC_Root_CA_-_R4.crt
 AC_RAIZ_FNMT-RCM.crt                                                GlobalSign_ECC_Root_CA_-_R5.crt
@@ -1184,7 +1184,7 @@ public class CertTrust {
 
 Validation results for Expired Certificate:
 
-```ls
+```txt
 Certificate chain validation failed: java.security.cert.CertPathValidatorException: timestamp check failed :
   java.security.cert.CertificateExpiredException: NotAfter: Sat Mar 17 02:59:59 MSK 2018
 Default trust manager: certificate chain validation failed:
@@ -1195,7 +1195,7 @@ Default trust manager: certificate chain validation failed:
 
 Validation Results for Self-Signed Certificate:
 
-```ls
+```txt
 Certificate chain validation failed: java.security.cert.CertPathValidatorException: Path does not chain with any of the trust anchors : null
 
 Default trust manager: certificate chain validation failed: sun.security.validator.ValidatorException: PKIX path building failed:


### PR DESCRIPTION
Refactor ChartLab code blocks to use `ls` dialect instead of `css`.