### PR TITLE
sandbox-links

### DIFF
--- a/integrations/aws/cloud-watch-alert/README.md
+++ b/integrations/aws/cloud-watch-alert/README.md
@@ -70,7 +70,7 @@ Follow the quick [launch procedure](#launch-sandbox-with-automated-slack-and-ema
 
 Follow this procedure to send AWS CloudWatch events into ATSD to enrich standard SNS notifications with additional resource details and AWS console links.
 
-* Launch an [ATSD sandbox](https://github.com/axibase/dockers/tree/atsd-sandbox):
+* Launch an [ATSD sandbox](https://github.com/axibase/dockers/blob/atsd-sandbox/README.md#atsd-sandbox-docker-image):
 
 ```sh
 docker run -d -p 8443:8443 \

--- a/integrations/aws/route53-health-checks/README.md
+++ b/integrations/aws/route53-health-checks/README.md
@@ -82,7 +82,7 @@ Offload health check statistics to ATSD and create consolidated dashboards with 
 ### Prerequisites
 
 * Create an AWS [IAM account](https://axibase.com/docs/axibase-collector/jobs/aws-iam.html) to query CloudWatch statistics.
-* Ensure 4 GB RAM is available for the [ATSD sandbox](https://github.com/axibase/dockers/tree/atsd-sandbox) container.
+* Ensure 4 GB RAM is available for the [ATSD sandbox](https://github.com/axibase/dockers/blob/atsd-sandbox/README.md#atsd-sandbox-docker-image) container.
 
 ### Launch ATSD Sandbox
 
@@ -102,7 +102,7 @@ accessKeyId=KEY
 secretAccessKey=SECRET
 ```
 
-Launch the [ATSD sandbox](https://github.com/axibase/dockers/tree/atsd-sandbox) container on a Docker host:
+Launch the [ATSD sandbox](https://github.com/axibase/dockers/blob/atsd-sandbox/README.md#atsd-sandbox-docker-image) container on a Docker host:
 
 ```sh
 docker run -d -p 8443:8443 -p 9443:9443 -p 8081:8081 \

--- a/integrations/docker/README.md
+++ b/integrations/docker/README.md
@@ -139,7 +139,7 @@ Set `NOTIFY_URL` variable to a request URL where `on-error` webhook notification
 
 The notification URL may include **Basic** authorization credentials, for example `https://username:password@atsd_hostname:10443/`. SSL certificate validation is disabled by default.
 
-Execute the command below to launch an [ATSD Sandbox](https://github.com/axibase/dockers/tree/atsd-sandbox) container.
+Execute the command below to launch an [ATSD Sandbox](https://github.com/axibase/dockers/blob/atsd-sandbox/README.md#atsd-sandbox-docker-image) container.
 
 ```sh
 docker run -d -p 8443:8443 -p 9443:9443 \

--- a/integrations/kafka/brokers-monitoring/README.md
+++ b/integrations/kafka/brokers-monitoring/README.md
@@ -9,11 +9,11 @@ This guide describes how to monitor availability and performance of [Apache Kafk
 ### Prerequisites
 
 * Kafka brokers with enabled JMX.
-* 4 GB RAM for the [ATSD sandbox](https://github.com/axibase/dockers/tree/atsd-sandbox) container.
+* 4 GB RAM for the [ATSD sandbox](https://github.com/axibase/dockers/blob/atsd-sandbox/README.md#atsd-sandbox-docker-image) container.
 
 ### Launch ATSD Sandbox
 
-Launch [ATSD sandbox](https://github.com/axibase/dockers/tree/atsd-sandbox) container on one of the Docker hosts:
+Launch [ATSD sandbox](https://github.com/axibase/dockers/blob/atsd-sandbox/README.md#atsd-sandbox-docker-image) container on one of the Docker hosts:
 
 ```sh
 docker run -d -p 8443:8443 -p 9443:9443 -p 8081:8081 \

--- a/integrations/marathon/capacity-and-usage/README.md
+++ b/integrations/marathon/capacity-and-usage/README.md
@@ -41,7 +41,7 @@ Integration with ATSD adds an additional level of visibility by collecting and a
 
 ### Launch ATSD Sandbox
 
-Launch [ATSD sandbox](https://github.com/axibase/dockers/tree/atsd-sandbox) container on one of the Docker hosts.
+Launch [ATSD sandbox](https://github.com/axibase/dockers/blob/atsd-sandbox/README.md#atsd-sandbox-docker-image) container on one of the Docker hosts.
 
 Replace `marathon_hostname`, `username`, and `password` in the command below with actual Marathon user credentials.
 


### PR DESCRIPTION
The links to `atsd-sandbox` branch of `dockers` repo don't do it justice. I linked directory to the header so the user doesn't have to scroll past the directory index when they follow the link.