### PR TITLE
add-top-menu-link

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -5,11 +5,12 @@ const githubSettings = {
 }
 
 const topNavMenu = [
-    { text: 'Research', link: '/research/' },
     { text: 'Chart of the Day', link: '/chart-of-the-day/' },
-    { text: 'Trends', link: '/trends/' },
     { text: 'Integrations', link: '/integrations/' },
+    { text: 'Research', link: '/research/' },
+    { text: 'Trends', link: '/trends/' },
     { text: 'Tutorials', link: '/tutorials/' },
+    { text: 'Workshops', link: '/workshop/'},
     { text: 'Docs', link: 'https://axibase.com/docs/atsd/' },
 ]
 


### PR DESCRIPTION
This PR adds the Workshops directory to the top navigation menu in `vuepress.js` document.

![image](https://user-images.githubusercontent.com/29099829/48045983-97f2f100-e1a3-11e8-9fb9-e304991b48ba.png)

I alphabetized the links as with the left navigation menu, but left Docs at the end since it is a separate entity.