### PR TITLE
remove-with

### DIFF
--- a/integrations/github/fork-notification.md
+++ b/integrations/github/fork-notification.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This guide shows how to configure GitHub to alert you when someone forks your repository. This feature allows you to monitor activity related to your repository. Follow the instructions to configure ATSD to send you the notifications directly through a third-party messenger service with.
+This guide shows how to configure GitHub to alert you when someone forks your repository. This feature allows you to monitor activity related to your repository. Follow the instructions to configure ATSD to send you the notifications directly through a third-party messenger service.
 
 ![](./images/workflow_fork.png)
 

--- a/integrations/github/issue-notification.md
+++ b/integrations/github/issue-notification.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This guide shows how to configure GitHub to alert you when someone raises an issue in your repository. This feature allows you to monitor your repository and receive notifications the moment an issue is raised. Follow the instructions to configure ATSD to send you the notifications directly through a third-party messenger service with.
+This guide shows how to configure GitHub to alert you when someone raises an issue in your repository. This feature allows you to monitor your repository and receive notifications the moment an issue is raised. Follow the instructions to configure ATSD to send you the notifications directly through a third-party messenger service.
 
 ![](./images/workflow_issue.png)
 

--- a/integrations/github/pr-notification.md
+++ b/integrations/github/pr-notification.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This guide shows how to configure GitHub to alert you when anyone opens a new pull request in your repository. This feature allows you to monitor your repository and receive notifications the moment a new PR is opened. Follow the instructions to configure ATSD to send you the notifications directly through a third-party messenger service with.
+This guide shows how to configure GitHub to alert you when anyone opens a new pull request in your repository. This feature allows you to monitor your repository and receive notifications the moment a new PR is opened. Follow the instructions to configure ATSD to send you the notifications directly through a third-party messenger service.
 
 ![](./images/workflow_pr.png)
 

--- a/integrations/github/project-release-notification.md
+++ b/integrations/github/project-release-notification.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This guide shows how to configure GitHub to alert you when someone creates a new project in your repository. This feature allows you to monitor your repository and receive notifications the moment a project is created. Follow the instructions to configure ATSD to send you the notifications directly through a third-party messenger service with.
+This guide shows how to configure GitHub to alert you when someone creates a new project in your repository. This feature allows you to monitor your repository and receive notifications the moment a project is created. Follow the instructions to configure ATSD to send you the notifications directly through a third-party messenger service.
 
 ![](./images/workflow_project.png)
 

--- a/integrations/github/push-notification.md
+++ b/integrations/github/push-notification.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This guide shows how to configure GitHub to alert you when someone pushes to your repository. This feature allows you to monitor the dataflow in your repository. Follow the instructions to configure ATSD to send you the notifications directly through a third-party messenger service with.
+This guide shows how to configure GitHub to alert you when someone pushes to your repository. This feature allows you to monitor the dataflow in your repository. Follow the instructions to configure ATSD to send you the notifications directly through a third-party messenger service.
 
 ![](./images/workflow_push.png)
 

--- a/integrations/github/watch-notification.md
+++ b/integrations/github/watch-notification.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This guide shows how to configure GitHub to alert you when someone begins to watch your repository. This feature allows you to monitor your repository followers. Follow the instructions to configure ATSD to send you the notifications directly through a third-party messenger service with.
+This guide shows how to configure GitHub to alert you when someone begins to watch your repository. This feature allows you to monitor your repository followers. Follow the instructions to configure ATSD to send you the notifications directly through a third-party messenger service.
 
 ![](./images/workflow_watch.png)
 


### PR DESCRIPTION
In all of the GitHub integration articles there is an unusual "with" occurrence at the end of each of the introduction paragraphs. Not sure how to explain its presence, but his PR removes them.