### PR TITLE
remove-back-ticks

### DIFF
--- a/workshop/README.md
+++ b/workshop/README.md
@@ -2,10 +2,14 @@
 
 Internal Axibase knowledge seminars made public for secondary use or personal learning.
 
+<!-- markdownlint-disable MD101 -->
+
 1. [The Evolution of Time Zones](./timezones.md) (November 2018)
 1. [Roman Time Keeping](https://axibase.com/files/roman-time-keeping/assets/player/KeynoteDHTMLPlayer.html#0) (November 2018) <sup>Available in [PDF](https://axibase.com/files/roman-time-keeping/roman_time_keeping.pdf) format.</sup>
 1. [Code Inspection with SonarQube](./sonar.md) (July 2018)
 1. [Practical Java Performance: Date Formatting Optimization](./performance.md) (June 2018)
 1. [Technical Writing for Software Developers](./technical-writing.md) (May 2018)
-1. [`Let's Encrypt` SSL Certificates for Java Developers](./lets-encrypt.md) (May 2018)
+1. [Let's Encrypt SSL Certificates for Java Developers](./lets-encrypt.md) (May 2018)
 1. [WebGL: Hello, World and Integration Examples](./webgl.md) (April 2018)
+
+<!-- markdownlint-enable MD101 -->


### PR DESCRIPTION
We added the Let's Encrypt workshop before we started using the <!--- markdownlint-disable MD###> syntax to ignore certain rules as needed. Looks like we never implemented this technique on the workshops ToC. This PR adds that syntax so Let's Encrypt may be written like other company/product names despite containing a hyphen.